### PR TITLE
Build fix.

### DIFF
--- a/src/ExtendedXmlSerializer/Properties/AssemblyInfo.cs
+++ b/src/ExtendedXmlSerializer/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("ExtendedXmlSerializer")]
 [assembly: AssemblyTrademark("")]
-[assembly: InternalsVisibleTo("ExtendedXmlSerializerTest")]
+[assembly: InternalsVisibleTo("ExtendedXmlSerializerTest, PublicKey=00240000048000009400000006020000002400005253413100040000010001001b1e766f975691c227ac39ebb9b2d2e71dde1f0e148412ecd710781790f3e694dbd6330fb45e11cff2775c2f15a9eede436b0053ce17aaf89ed9f01aac91fc661934d38422c7ef5b81db01848113b3c0e094657e090a615203aef49ea67976182471b0456f7ff7c545d40d9dd6a169f2f292f978702aae1d246cd8f4833e36e7")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
@@ -79,13 +79,13 @@ namespace ExtendedXmlSerialization.Test
 			Assert.Equal(expected, _serializer.Serialize(read));
 		}
 
-		[Fact]
+		/*[Fact]
 		public void Array()
 		{
 			var instance = new[] {1, 2, 3, 4, 5};
 			var data = _serializer.Serialize(instance);
 			Debugger.Break();
-		}
+		}*/
 
 /*
 		[Fact]

--- a/test/ExtendedXmlSerializerTest/Legacy/Resources/TestClassGenericThree.xml
+++ b/test/ExtendedXmlSerializerTest/Legacy/Resources/TestClassGenericThree.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TestClassGenericThreeOfStringInt32TestClassPrimitiveTypes type="ExtendedXmlSerialization.Test.TestObject.TestClassGenericThree`3[[System.String, [CORELIB]],[System.Int32, [CORELIB]],[ExtendedXmlSerialization.Test.TestObject.TestClassPrimitiveTypes, ExtendedXmlSerializerTest, Version=[EXTENDEDXMLSERIALIZER_VERSION], Culture=neutral, PublicKeyToken=null]]">
+<TestClassGenericThreeOfStringInt32TestClassPrimitiveTypes type="ExtendedXmlSerialization.Test.TestObject.TestClassGenericThree`3[[System.String, [CORELIB]],[System.Int32, [CORELIB]],[ExtendedXmlSerialization.Test.TestObject.TestClassPrimitiveTypes, ExtendedXmlSerializerTest, Version=[EXTENDEDXMLSERIALIZER_VERSION], Culture=neutral, PublicKeyToken=0311609c42bdb381]]">
   <GenericProp>StringValue</GenericProp>
   <GenericProp2>1</GenericProp2>
   <GenericProp3 type="ExtendedXmlSerialization.Test.TestObject.TestClassPrimitiveTypes">

--- a/test/ExtendedXmlSerializerTest/project.json
+++ b/test/ExtendedXmlSerializerTest/project.json
@@ -2,9 +2,10 @@
   "title": "ExtendedXmlSerialization.Test",
   "testRunner": "xunit",
   "version": "1.5.0",
-  "buildOptions": {
-    "embed": [ "Resources/*.xml", "Legacy/Resources/*.xml" ]
-  },
+    "buildOptions": {
+        "keyFile": "../../ExtendedXmlSerializer.snk",
+        "embed": [ "Resources/*.xml", "Legacy/Resources/*.xml" ]
+    },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "ExtendedXmlSerializer": {


### PR DESCRIPTION
Fixing problem with the visibility of tests.  Had to sign the test assembly and use its public key in an `InternalsVisibleTo` attribute.