### PR TITLE
Feature/collection-members

### DIFF
--- a/src/ExtendedXmlSerializer/Configuration/Defaults.cs
+++ b/src/ExtendedXmlSerializer/Configuration/Defaults.cs
@@ -1,0 +1,44 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Members;
+
+namespace ExtendedXmlSerialization.Configuration
+{
+	static class Defaults
+	{
+		public static MemberSpecification<FieldInfo> Field { get; } =
+			new MemberSpecification<FieldInfo>(FieldMemberSpecification.Default);
+
+		public static MemberSpecification<PropertyInfo> Property { get; } =
+			new MemberSpecification<PropertyInfo>(PropertyMemberSpecification.Default);
+
+		public static IMemberPolicy MemberPolicy { get; } = new BlacklistMemberPolicy(
+			typeof(IDictionary<,>).GetRuntimeProperty(nameof(IDictionary.Keys)),
+			typeof(IDictionary<,>).GetRuntimeProperty(nameof(IDictionary.Values))
+		);
+	}
+}

--- a/src/ExtendedXmlSerializer/Configuration/ExtendedXmlConfiguration.cs
+++ b/src/ExtendedXmlSerializer/Configuration/ExtendedXmlConfiguration.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Xml;
+using ExtendedXmlSerialization.ContentModel.Members;
 
 namespace ExtendedXmlSerialization.Configuration
 {
@@ -40,9 +41,9 @@ namespace ExtendedXmlSerialization.Configuration
 
 		public bool AutoProperties { get; set; }
 		public bool Namespaces { get; set; }
-        public XmlReaderSettings ReaderSettings { get; set; }
-        public XmlWriterSettings WriterSettings { get; set; }
-        public IPropertyEncryption EncryptionAlgorithm { get; set; }
+		public XmlReaderSettings ReaderSettings { get; set; }
+		public XmlWriterSettings WriterSettings { get; set; }
+		public IPropertyEncryption EncryptionAlgorithm { get; set; }
 
 		IExtendedXmlTypeConfiguration IInternalExtendedXmlConfiguration.GetTypeConfiguration(Type type)
 		{
@@ -80,16 +81,25 @@ namespace ExtendedXmlSerialization.Configuration
 
 		public IExtendedXmlSerializer Create() => _factory.Get(this);
 
-	    public IExtendedXmlConfiguration WithSettings(XmlReaderSettings readerSettings)
-	    {
-	        ReaderSettings = readerSettings;
-	        return this;
-	    }
+		public IExtendedXmlConfiguration WithSettings(XmlReaderSettings readerSettings)
+		{
+			ReaderSettings = readerSettings;
+			return this;
+		}
 
-        public IExtendedXmlConfiguration WithSettings(XmlWriterSettings writerSettings)
-        {
-            WriterSettings = writerSettings;
-            return this;
-        }
-    }
+		public IExtendedXmlConfiguration WithSettings(XmlWriterSettings writerSettings)
+		{
+			WriterSettings = writerSettings;
+			return this;
+		}
+		
+		public IExtendedXmlConfiguration WithSettings(XmlReaderSettings readerSettings, XmlWriterSettings writerSettings)
+		{
+			ReaderSettings = readerSettings;
+			WriterSettings = writerSettings;
+			return this;
+		}
+
+		public IMemberPolicy Get() => Defaults.MemberPolicy; // TODO. Create policy.
+	}
 }

--- a/src/ExtendedXmlSerializer/Configuration/ExtendedXmlSerializerFactory.cs
+++ b/src/ExtendedXmlSerializer/Configuration/ExtendedXmlSerializerFactory.cs
@@ -21,16 +21,37 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.Core.Specifications;
+
 namespace ExtendedXmlSerialization.Configuration
 {
 	class ExtendedXmlSerializerFactory : IExtendedXmlSerializerFactory
 	{
+		readonly static TypeSelector Selector = TypeSelector.Default;
+		readonly static XmlFactory XmlFactory = XmlFactory.Default;
+
 		public static ExtendedXmlSerializerFactory Default { get; } = new ExtendedXmlSerializerFactory();
-		ExtendedXmlSerializerFactory() {}
+		ExtendedXmlSerializerFactory() : this(Defaults.Property, Defaults.Field) {}
+
+		readonly ISpecification<PropertyInfo> _property;
+		readonly ISpecification<FieldInfo> _field;
+
+		public ExtendedXmlSerializerFactory(ISpecification<PropertyInfo> property, ISpecification<FieldInfo> field)
+		{
+			_property = property;
+			_field = field;
+		}
 
 		public IExtendedXmlSerializer Get(IExtendedXmlConfiguration parameter)
 		{
-			return new ExtendedXmlSerializer();
+			var policy = parameter.Get();
+			var serializers = new Serializers(_property.And(policy), _field.And(policy));
+			var result = new ExtendedXmlSerializer(Selector, XmlFactory, serializers);
+			return result;
 		}
 	}
 }

--- a/src/ExtendedXmlSerializer/Configuration/IExtendedXmlConfiguration.cs
+++ b/src/ExtendedXmlSerializer/Configuration/IExtendedXmlConfiguration.cs
@@ -22,17 +22,19 @@
 // SOFTWARE.
 
 using System.Xml;
+using ExtendedXmlSerialization.ContentModel.Members;
+using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.Configuration
 {
-	public interface IExtendedXmlConfiguration
+	public interface IExtendedXmlConfiguration : ISource<IMemberPolicy>
 	{
 		IExtendedXmlTypeConfiguration<T> ConfigureType<T>();
 		IExtendedXmlConfiguration UseAutoProperties();
 		IExtendedXmlConfiguration UseNamespaces();
 		IExtendedXmlConfiguration UseEncryptionAlgorithm(IPropertyEncryption propertyEncryption);
 		IExtendedXmlSerializer Create();
-	    IExtendedXmlConfiguration WithSettings(XmlReaderSettings readerSettings);
-	    IExtendedXmlConfiguration WithSettings(XmlWriterSettings writerSettings);
+		IExtendedXmlConfiguration WithSettings(XmlReaderSettings readerSettings);
+		IExtendedXmlConfiguration WithSettings(XmlWriterSettings writerSettings);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Activator.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Activator.cs
@@ -34,19 +34,13 @@ namespace ExtendedXmlSerialization.ContentModel
 
 	class Activator : IReader
 	{
-		readonly static TypeSelector Selector = TypeSelector.Default;
-
-		readonly ITypeSelector _selector;
 		readonly IActivators _activators;
 
-		public Activator(IActivators activators) : this(Selector, activators) {}
-
-		public Activator(ITypeSelector selector, IActivators activators)
+		public Activator(IActivators activators)
 		{
-			_selector = selector;
 			_activators = activators;
 		}
 
-		public object Get(IXmlReader parameter) => _activators.Get(_selector.Get(parameter).AsType()).Invoke();
+		public object Get(IXmlReader parameter) => _activators.Get(parameter.Classification.AsType()).Invoke();
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Activator.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Activator.cs
@@ -34,13 +34,19 @@ namespace ExtendedXmlSerialization.ContentModel
 
 	class Activator : IReader
 	{
+		readonly static TypeSelector TypeSelector = TypeSelector.Default;
+
+		readonly ITypeSelector _selector;
 		readonly IActivators _activators;
 
-		public Activator(IActivators activators)
+		public Activator(IActivators activators) : this(TypeSelector, activators) {}
+
+		public Activator(ITypeSelector selector, IActivators activators)
 		{
+			_selector = selector;
 			_activators = activators;
 		}
 
-		public object Get(IXmlReader parameter) => _activators.Get(parameter.Classification.AsType()).Invoke();
+		public object Get(IXmlReader parameter) => _activators.Get(_selector.Get(parameter).AsType()).Invoke();
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/AliasesBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/AliasesBase.cs
@@ -22,12 +22,11 @@
 // SOFTWARE.
 
 using System.Reflection;
-using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel
 {
-	public abstract class AliasesBase<T> : ReferenceCacheBase<T, string>, IAliases<T> where T : MemberInfo
+	public abstract class AliasesBase<T> : IAliases<T> where T : MemberInfo
 	{
-		// public abstract string Get(T parameter);
+		public abstract string Get(T parameter);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayContentOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayContentOption.cs
@@ -32,10 +32,6 @@ namespace ExtendedXmlSerialization.ContentModel.Collections
 		public ArrayContentOption(ISerializers serializer) : base(IsArraySpecification.Default, serializer) {}
 
 		protected override ISerializer Create(ISerializer item, TypeInfo classification)
-		{
-			var reader = new ArrayReader(item);
-			var result = new Serializer(reader, new EnumerableWriter(item));
-			return result;
-		}
+			=> new Serializer(new ArrayReader(item), new EnumerableWriter(item));
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayContentOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayContentOption.cs
@@ -29,12 +29,12 @@ namespace ExtendedXmlSerialization.ContentModel.Collections
 {
 	class ArrayContentOption : CollectionContentOptionBase
 	{
-		public ArrayContentOption(IContainers container) : base(IsArraySpecification.Default, container) {}
+		public ArrayContentOption(ISerializers serializer) : base(IsArraySpecification.Default, serializer) {}
 
 		protected override ISerializer Create(ISerializer item, TypeInfo classification)
 		{
 			var reader = new ArrayReader(item);
-			var result = new DecoratedSerializer(reader, new EnumerableWriter(item));
+			var result = new Serializer(reader, new EnumerableWriter(item));
 			return result;
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayElement.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayElement.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.ContentModel.Content;
 using ExtendedXmlSerialization.ContentModel.Properties;
 using ExtendedXmlSerialization.ContentModel.Xml;
@@ -34,11 +33,11 @@ namespace ExtendedXmlSerialization.ContentModel.Collections
 	{
 		readonly ITypeProperty _property;
 		readonly TypeInfo _element;
-		readonly static XName Name = Names.Default.Get(typeof(Array).GetTypeInfo());
+		readonly static IIdentity Identity = Xml.Identities.Default.Get(typeof(Array).GetTypeInfo());
 
 		public ArrayElement(TypeInfo element) : this(ItemTypeProperty.Default, element) {}
 
-		public ArrayElement(ITypeProperty property, TypeInfo element) : base(Name)
+		public ArrayElement(ITypeProperty property, TypeInfo element) : base(Identity.Name, Identity.Identifier)
 		{
 			_property = property;
 			_element = element;

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/ArrayReader.cs
@@ -22,25 +22,28 @@
 // SOFTWARE.
 
 using System.Collections;
+using ExtendedXmlSerialization.ContentModel.Content;
 using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.Core;
-using ExtendedXmlSerialization.TypeModel;
 
 namespace ExtendedXmlSerialization.ContentModel.Collections
 {
-	class ArrayReader : CollectionReader
+	class ArrayReader : ActivatedContentsReader
 	{
-		readonly static AddDelegates Add = AddDelegates.Default;
+		readonly ITypeSelector _selector;
+		readonly static TypeSelector TypeSelector = TypeSelector.Default;
 
-		public ArrayReader(ISerializer item) : this(item, Add) {}
+		public ArrayReader(ISerializer item) : this(TypeSelector, new CollectionContentsReader(item)) {}
 
-		public ArrayReader(ISerializer item, IAddDelegates add) : base(Activator<ArrayList>.Default, item, add)
+		public ArrayReader(ITypeSelector selector, IContentsReader contents) : base(Activator<ArrayList>.Default, contents)
 		{
+			_selector = selector;
 		}
 
 		public override object Get(IXmlReader parameter)
 		{
-			var elementType = parameter.Classification.GetElementType();
+			var classification = _selector.Get(parameter);
+			var elementType = classification.GetElementType();
 			var list = base.Get(parameter).AsValid<ArrayList>();
 			var result = list.ToArray(elementType);
 			return result;

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionContentOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionContentOption.cs
@@ -31,10 +31,10 @@ namespace ExtendedXmlSerialization.ContentModel.Collections
 	{
 		readonly IActivators _activators;
 
-		public CollectionContentOption(IContainers containers) : this(containers, Activators.Default) {}
+		public CollectionContentOption(ISerializers serializers) : this(serializers, Activators.Default) {}
 
-		public CollectionContentOption(IContainers containers, IActivators activators)
-			: base(containers)
+		public CollectionContentOption(ISerializers serializers, IActivators activators)
+			: base(serializers)
 		{
 			_activators = activators;
 		}
@@ -43,7 +43,7 @@ namespace ExtendedXmlSerialization.ContentModel.Collections
 		{
 			var activator = new DelegatedFixedActivator(_activators.Get(classification.AsType()));
 			var reader = new CollectionReader(activator, item);
-			var result = new DecoratedSerializer(reader, new EnumerableWriter(item));
+			var result = new Serializer(reader, new EnumerableWriter(item));
 			return result;
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionContentOptionBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionContentOptionBase.cs
@@ -30,26 +30,29 @@ namespace ExtendedXmlSerialization.ContentModel.Collections
 {
 	abstract class CollectionContentOptionBase : ContentOptionBase
 	{
-		readonly IContainers _containers;
+		readonly static AllSpecification<TypeInfo> Specification =
+			new AllSpecification<TypeInfo>(IsActivatedTypeSpecification.Default, IsCollectionTypeSpecification.Default);
+
+		readonly ISerializers _serializers;
 		readonly ICollectionItemTypeLocator _locator;
 
-		protected CollectionContentOptionBase(IContainers containers)
-			: this(IsCollectionTypeSpecification.Default, containers) {}
+		protected CollectionContentOptionBase(ISerializers serializers)
+			: this(Specification, serializers) {}
 
-		protected CollectionContentOptionBase(ISpecification<TypeInfo> specification, IContainers containers)
-			: this(specification, containers, CollectionItemTypeLocator.Default) {}
+		protected CollectionContentOptionBase(ISpecification<TypeInfo> specification, ISerializers serializers)
+			: this(specification, serializers, CollectionItemTypeLocator.Default) {}
 
-		protected CollectionContentOptionBase(ISpecification<TypeInfo> specification, IContainers containers,
+		protected CollectionContentOptionBase(ISpecification<TypeInfo> specification, ISerializers serializers,
 		                                      ICollectionItemTypeLocator locator) : base(specification)
 		{
-			_containers = containers;
+			_serializers = serializers;
 			_locator = locator;
 		}
 
 		public override ISerializer Get(TypeInfo parameter)
 		{
 			var itemType = _locator.Get(parameter);
-			var result = Create(_containers.Get(itemType), parameter);
+			var result = Create(_serializers.Get(itemType), parameter);
 			return result;
 		}
 

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionContentsReader.cs
@@ -21,26 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Reflection;
-using ExtendedXmlSerialization.ContentModel;
-using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
-using Xunit;
-using TypeFormatter = ExtendedXmlSerialization.ContentModel.Xml.TypeFormatter;
+using ExtendedXmlSerialization.ContentModel.Content;
 
-namespace ExtendedXmlSerialization.Test.ContentModel.Xml
+namespace ExtendedXmlSerialization.ContentModel.Collections
 {
-	public class AssemblyPartitionedTypesTests
+	class CollectionContentsReader : ContentsReader
 	{
-		[Fact]
-		public void TestName()
-		{
-			var expected = typeof(Subject).GetTypeInfo();
-			var @namespace = NamespaceFormatter.Default.Get(expected);
-			var type = AssemblyPartitionedTypes.Default.Get(new Identity(TypeFormatter.Default.Get(expected), @namespace));
-			Assert.Equal(expected, type);
-		}
+		public CollectionContentsReader(ISerializer item) : this(new CollectionItemContentsReader(item)) {}
 
-		sealed class Subject {}
+		public CollectionContentsReader(IContentsReader contents) : base(contents) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionItemContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/CollectionItemContentsReader.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
-using System.Reflection;
+using System.Collections;
+using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Xml;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Collections
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	class CollectionItemContentsReader : IContentsReader
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
+		readonly ISerializer _item;
+		readonly ILists _lists;
 
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
+		public CollectionItemContentsReader(ISerializer item) : this(item, Lists.Default) {}
 
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
+		public CollectionItemContentsReader(ISerializer item, ILists lists)
 		{
-			_interfaces = interfaces;
-			_identity = identity;
+			_item = item;
+			_lists = lists;
 		}
 
-		public bool Equals(TypeInfo x, TypeInfo y)
+		public void Read(IXmlReader reader, object instance)
 		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
+			var list = instance as IList ?? _lists.Get(instance);
+			var item = _item.Get(reader);
+			list.Add(item);
 		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/DictionaryEntryWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/DictionaryEntryWriter.cs
@@ -1,0 +1,34 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
+
+namespace ExtendedXmlSerialization.ContentModel.Collections
+{
+	class DictionaryEntryWriter : EnumerableWriter<IDictionary>
+	{
+		public DictionaryEntryWriter(IWriter entry) : base(entry) {}
+
+		protected override IEnumerator Get(IDictionary instance) => instance.GetEnumerator();
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/ILists.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/ILists.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
-using System.Reflection;
+using System.Collections;
+using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Collections
 {
-	public class ImplementedTypeComparer : ITypeComparer
-	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
-
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
-		{
-			_interfaces = interfaces;
-			_identity = identity;
-		}
-
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
-	}
+	public interface ILists : IParameterizedSource<object, IList> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/MemberedCollectionContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/MemberedCollectionContentsReader.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Immutable;
 using System.Linq;
-using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Members;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Collections
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	class MemberedCollectionContentsReader : ContentsReader
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
+		public MemberedCollectionContentsReader(ImmutableArray<IMember> members, ISerializer item)
+			: this(members, item, Lists.Default) {}
 
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
-		{
-			_interfaces = interfaces;
-			_identity = identity;
-		}
-
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		public MemberedCollectionContentsReader(ImmutableArray<IMember> members, ISerializer item, ILists lists) : base(
+			new SelectingContentsReader(members.ToDictionary(x => x.DisplayName), new CollectionItemContentsReader(item, lists))) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Collections/MemberedCollectionWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Collections/MemberedCollectionWriter.cs
@@ -1,0 +1,43 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using ExtendedXmlSerialization.ContentModel.Xml;
+
+namespace ExtendedXmlSerialization.ContentModel.Collections
+{
+	class MemberedCollectionWriter : DecoratedWriter
+	{
+		readonly IWriter _entries;
+
+		public MemberedCollectionWriter(IWriter members, IWriter entries) : base(members)
+		{
+			_entries = entries;
+		}
+
+		public override void Write(IXmlWriter writer, object instance)
+		{
+			base.Write(writer, instance);
+			_entries.Write(writer, instance);
+		}
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ActivatedContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ActivatedContentsReader.cs
@@ -1,6 +1,6 @@
-// MIT License
+﻿// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nag�rski
+// Copyright (c) 2016 Wojciech Nagórski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,36 +21,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
-using System.Reflection;
 using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core;
-using ExtendedXmlSerialization.TypeModel;
 
-namespace ExtendedXmlSerialization.ContentModel.Collections
+namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	class CollectionReader : DecoratedReader
+	class ActivatedContentsReader : DecoratedReader
 	{
-		readonly ISerializer _item;
-		readonly IAddDelegates _add;
+		readonly IContentsReader _contents;
 
-		public CollectionReader(IReader activator, ISerializer item) : this(activator, item, AddDelegates.Default) {}
-
-		public CollectionReader(IReader activator, ISerializer item, IAddDelegates add) : base(activator)
+		public ActivatedContentsReader(IReader activator, IContentsReader contents) : base(activator)
 		{
-			_item = item;
-			_add = add;
+			_contents = contents;
 		}
 
 		public override object Get(IXmlReader parameter)
 		{
 			var result = base.Get(parameter);
-			var list = result as IList ?? new ListAdapter(result, _add.Get(result.GetType().GetTypeInfo()));
-			var items = parameter.Items();
-			while (items.MoveNext())
-			{
-				list.Add(_item.Get(parameter));
-			}
+			_contents.Read(parameter, result);
 			return result;
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/Container.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/Container.cs
@@ -23,8 +23,15 @@
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	class Container : DecoratedSerializer
+	class Container : Serializer, IContainer
 	{
-		public Container(IWriter element, ISerializer body) : base(body, new Enclosure(element, body)) {}
+		readonly ISerializer _content;
+
+		public Container(IWriter element, ISerializer content) : base(content, new Enclosure(element, content))
+		{
+			_content = content;
+		}
+
+		public ISerializer Get() => _content;
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ContainerDefinitions.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ContainerDefinitions.cs
@@ -44,16 +44,18 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 			_known = known;
 		}
 
-		public IEnumerable<ContainerDefinition> Get(IContainers parameter)
+		public IEnumerable<ContainerDefinition> Get(ISerializers parameter)
 		{
 			var runtime = new RuntimeSerializer(parameter);
 			var variable = new VariableTypeMemberOption(parameter, runtime);
+			var members = new Members.Members(parameter, new Selector(parameter, variable));
+
 			yield return new ContainerDefinition(ElementOption.Default, _known);
 			yield return new ContainerDefinition(ArrayElementOption.Default, new ArrayContentOption(parameter));
-			yield return new ContainerDefinition(new DictionaryContentOption(variable));
+			yield return new ContainerDefinition(new DictionaryContentOption(members, variable));
 			yield return new ContainerDefinition(new CollectionContentOption(parameter));
 
-			yield return new ContainerDefinition(new MemberedContentOption(new Selector(parameter, variable)));
+			yield return new ContainerDefinition(new MemberedContentOption(members));
 			yield return new ContainerDefinition(new RuntimeContentOption(runtime));
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ContainerDefinitions.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ContainerDefinitions.cs
@@ -37,7 +37,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 		public ContainerDefinitions() : this(OptimizedConverterAlteration.Default) {}
 
 		public ContainerDefinitions(IAlteration<IConverter> alteration)
-			: this(new CompositeContentOption(new WellKnownContent(alteration).ToArray())) {}
+			: this(new CompositeContentOption(new ContentOptions(alteration).ToArray())) {}
 
 		public ContainerDefinitions(IContentOption known)
 		{
@@ -53,7 +53,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 			yield return new ContainerDefinition(ElementOption.Default, _known);
 			yield return new ContainerDefinition(ArrayElementOption.Default, new ArrayContentOption(parameter));
 			yield return new ContainerDefinition(new DictionaryContentOption(members, variable));
-			yield return new ContainerDefinition(new CollectionContentOption(parameter));
+			yield return new ContainerDefinition(new CollectionContentOption(members, parameter));
 
 			yield return new ContainerDefinition(new MemberedContentOption(members));
 			yield return new ContainerDefinition(new RuntimeContentOption(runtime));

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ContainerSelector.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ContainerSelector.cs
@@ -34,7 +34,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 
 		public ContainerSelector(params ContainerDefinition[] definitions)
 			: this(
-				new Selector<TypeInfo, ISerializer>(definitions.Select(x => x.Content).ToArray()).ReferenceCache(), definitions) {}
+				new Selector<TypeInfo, ISerializer>(definitions.Select(x => x.Content).ToArray()).Cache(), definitions) {}
 
 		public ContainerSelector(IParameterizedSource<TypeInfo, ISerializer> content, params ContainerDefinition[] definitions)
 			: base(definitions.Select(x => new ContainerOption(x.Element, x.Content)).ToArray())

--- a/src/ExtendedXmlSerializer/ContentModel/Content/Containers.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/Containers.cs
@@ -38,7 +38,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 		public Containers(Func<IContainers, IEnumerable<ContainerDefinition>> definitions)
 		{
 			var selector = new ContainerSelector(definitions(this).ToArray());
-			_selector = selector.ReferenceCache().Get;
+			_selector = selector.Cache().Get;
 			_content = selector.Content;
 		}
 

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ContentOptions.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ContentOptions.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Converters;
+using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	class ContentOptions : Items<IContentOption>
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
+		public ContentOptions(IAlteration<IConverter> alteration)
+			: this(WellKnownConverters.Default, alteration, new EnumerationContentOption(alteration)) {}
 
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
-		{
-			_interfaces = interfaces;
-			_identity = identity;
-		}
-
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		public ContentOptions(IEnumerable<IConverter> converters, IAlteration<IConverter> alteration,
+		                      params IContentOption[] others) :
+			base(converters.Select(alteration.ToContent).Concat(others).ToArray()) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ContentsReader.cs
@@ -21,15 +21,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Reflection;
-using ExtendedXmlSerialization.Core.Specifications;
-using ExtendedXmlSerialization.TypeModel;
+using ExtendedXmlSerialization.ContentModel.Xml;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml
+namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	class CanPartitionSpecification : AnySpecification<TypeInfo>
+	class ContentsReader : DecoratedContentsReader
 	{
-		public static CanPartitionSpecification Default { get; } = new CanPartitionSpecification();
-		CanPartitionSpecification() : base(GenericActivatedTypeSpecification.Default, HasAliasSpecification.Default) {}
+		public ContentsReader(IContentsReader contents) : base(contents) {}
+
+		public override void Read(IXmlReader reader, object instance)
+		{
+			var target = reader.Depth + 1;
+			while (reader.Advance() && reader.Depth == target)
+			{
+				base.Read(reader, instance);
+			}
+		}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/DecoratedContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/DecoratedContentsReader.cs
@@ -21,20 +21,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
-using ExtendedXmlSerialization.ContentModel.Converters;
-using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.ContentModel.Xml;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	class WellKnownContent : Items<IContentOption>
+	class DecoratedContentsReader : IContentsReader
 	{
-		public WellKnownContent(IAlteration<IConverter> alteration)
-			: this(WellKnownConverters.Default, alteration, new EnumerationContentOption(alteration)) {}
+		readonly IContentsReader _reader;
 
-		public WellKnownContent(IEnumerable<IConverter> converters, IAlteration<IConverter> alteration,
-		                        params IContentOption[] others) :
-			base(converters.Select(alteration.ToContent).Concat(others).ToArray()) {}
+		public DecoratedContentsReader(IContentsReader reader)
+		{
+			_reader = reader;
+		}
+
+		public virtual void Read(IXmlReader reader, object instance) => _reader.Read(reader, instance);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/DictionaryContentOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/DictionaryContentOption.cs
@@ -21,7 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
 using System.Reflection;
 using ExtendedXmlSerialization.ContentModel.Collections;
 using ExtendedXmlSerialization.ContentModel.Members;
@@ -32,6 +31,8 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 {
 	class DictionaryContentOption : ContentOptionBase
 	{
+		readonly static ILists Lists = new Lists(DictionaryAddDelegates.Default);
+
 		readonly static AllSpecification<TypeInfo> Specification =
 			new AllSpecification<TypeInfo>(IsActivatedTypeSpecification.Default, IsDictionaryTypeSpecification.Default);
 
@@ -55,9 +56,12 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 			var item = _items.Get(parameter);
 			var members = _members.Get(parameter);
 			var activator = new DelegatedFixedActivator(_activators.Get(parameter.AsType()));
-			var dictionary = members.ToDictionary(x => x.DisplayName);
-			var memberedReader = new MemberedReader(activator, dictionary);
-			var reader = new CollectionReader(memberedReader, item, DictionaryAddDelegates.Default);
+
+			var reader = new ActivatedContentsReader(
+				activator,
+				new MemberedCollectionContentsReader(members, item, Lists)
+			);
+
 			var writer = new MemberedCollectionWriter(new MemberWriter(members), new DictionaryEntryWriter(item));
 			var result = new Serializer(reader, writer);
 			return result;

--- a/src/ExtendedXmlSerializer/ContentModel/Content/DictionaryItems.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/DictionaryItems.cs
@@ -59,7 +59,10 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 			var key = Create(Key, pair.KeyType);
 			var value = Create(Value, pair.ValueType);
 			var members = ImmutableArray.Create(key, value);
-			var reader = new MemberedReader(Activator<DictionaryEntry>.Default, members.ToDictionary(x => x.DisplayName));
+			var reader = new ActivatedContentsReader(Activator<DictionaryEntry>.Default,
+			                                         new ContentsReader(
+				                                         new MemberContentsReader(members.ToDictionary(x => x.DisplayName)))
+			);
 			var converter = new Serializer(reader, new MemberWriter(members));
 			var result = new Container(_element, converter);
 			return result;

--- a/src/ExtendedXmlSerializer/ContentModel/Content/DictionaryItems.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/DictionaryItems.cs
@@ -60,7 +60,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 			var value = Create(Value, pair.ValueType);
 			var members = ImmutableArray.Create(key, value);
 			var reader = new MemberedReader(Activator<DictionaryEntry>.Default, members.ToDictionary(x => x.DisplayName));
-			var converter = new DecoratedSerializer(reader, new MemberWriter(members));
+			var converter = new Serializer(reader, new MemberWriter(members));
 			var result = new Container(_element, converter);
 			return result;
 		}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/Element.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/Element.cs
@@ -21,20 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Xml.Linq;
 using ExtendedXmlSerialization.ContentModel.Xml;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	class Element : IWriter
+	class Element : Identity, IWriter
 	{
-		readonly XName _name;
+		public Element(string name, string identifier) : base(name, identifier) {}
 
-		public Element(XName name)
-		{
-			_name = name;
-		}
-
-		public virtual void Write(IXmlWriter writer, object instance) => writer.Element(_name);
+		public virtual void Write(IXmlWriter writer, object instance) => writer.Element(this);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ElementOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ElementOption.cs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 using System.Reflection;
-using System.Xml.Linq;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
@@ -31,6 +30,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 		public static ElementOption Default { get; } = new ElementOption();
 		ElementOption() {}
 
-		public override IWriter Create(XName name, TypeInfo classification) => new Element(name);
+		public override IWriter Create(IIdentity identity, TypeInfo classification)
+			=> new Element(identity.Name, identity.Identifier);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/GenericElement.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/GenericElement.cs
@@ -23,7 +23,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.ContentModel.Properties;
 using ExtendedXmlSerialization.ContentModel.Xml;
 
@@ -34,9 +33,11 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 		readonly IArgumentsProperty _property;
 		readonly ImmutableArray<Type> _arguments;
 
-		public GenericElement(XName name, ImmutableArray<Type> arguments) : this(ArgumentsProperty.Default, name, arguments) {}
+		public GenericElement(string name, string identifier, ImmutableArray<Type> arguments)
+			: this(ArgumentsProperty.Default, name, identifier, arguments) {}
 
-		public GenericElement(IArgumentsProperty property, XName name, ImmutableArray<Type> arguments) : base(name)
+		public GenericElement(IArgumentsProperty property, string name, string identifier, ImmutableArray<Type> arguments)
+			: base(name, identifier)
 		{
 			_property = property;
 			_arguments = arguments;

--- a/src/ExtendedXmlSerializer/ContentModel/Content/GenericElementOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/GenericElementOption.cs
@@ -23,7 +23,6 @@
 
 using System.Collections.Immutable;
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
@@ -33,7 +32,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 		public static GenericElementOption Default { get; } = new GenericElementOption();
 		GenericElementOption() : base(IsGenericTypeSpecification.Default) {}
 
-		public override IWriter Create(XName name, TypeInfo classification)
-			=> new GenericElement(name, classification.GetGenericArguments().ToImmutableArray());
+		public override IWriter Create(IIdentity identity, TypeInfo classification)
+			=> new GenericElement(identity.Name, identity.Identifier, classification.GetGenericArguments().ToImmutableArray());
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/IContainer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/IContainer.cs
@@ -1,0 +1,6 @@
+using ExtendedXmlSerialization.Core.Sources;
+
+namespace ExtendedXmlSerialization.ContentModel.Content
+{
+	public interface IContainer : ISerializer, ISource<ISerializer> {}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/IContainerDefinitions.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/IContainerDefinitions.cs
@@ -26,5 +26,5 @@ using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	public interface IContainerDefinitions : IParameterizedSource<IContainers, IEnumerable<ContainerDefinition>> {}
+	public interface IContainerDefinitions : IParameterizedSource<ISerializers, IEnumerable<ContainerDefinition>> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/IContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/IContentsReader.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
-using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Xml;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	public interface IContentsReader
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
-
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
-		{
-			_interfaces = interfaces;
-			_identity = identity;
-		}
-
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		void Read(IXmlReader reader, object instance);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/ISerializers.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/ISerializers.cs
@@ -23,10 +23,12 @@
 
 using System.Reflection;
 using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	public interface IContainers : IParameterizedSource<TypeInfo, ISerializer>
+	public interface ISerializers : IParameterizedSource<TypeInfo, ISerializer>, ISpecification<PropertyInfo>,
+	                                ISpecification<FieldInfo>
 	{
 		ISerializer Content(TypeInfo parameter);
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/NamedElementOptionBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/NamedElementOptionBase.cs
@@ -22,27 +22,25 @@
 // SOFTWARE.
 
 using System.Reflection;
-using System.Xml.Linq;
-using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
 {
-	public abstract class NamedElementOptionBase : ElementOptionBase
+	abstract class NamedElementOptionBase : ElementOptionBase
 	{
-		readonly INames _names;
+		readonly Xml.IIdentities _identities;
 
 		protected NamedElementOptionBase() : this(AlwaysSpecification<TypeInfo>.Default) {}
 
-		protected NamedElementOptionBase(ISpecification<TypeInfo> specification) : this(specification, Names.Default) {}
+		protected NamedElementOptionBase(ISpecification<TypeInfo> specification) : this(specification, Xml.Identities.Default) {}
 
-		protected NamedElementOptionBase(ISpecification<TypeInfo> specification, INames names) : base(specification)
+		protected NamedElementOptionBase(ISpecification<TypeInfo> specification, Xml.IIdentities identities) : base(specification)
 		{
-			_names = names;
+			_identities = identities;
 		}
 
-		public override IWriter Get(TypeInfo parameter) => Create(_names.Get(parameter), parameter);
+		public override IWriter Get(TypeInfo parameter) => Create(_identities.Get(parameter), parameter);
 
-		public abstract IWriter Create(XName name, TypeInfo classification);
+		public abstract IWriter Create(IIdentity identity, TypeInfo classification);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Content/SerializerSelector.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/SerializerSelector.cs
@@ -1,0 +1,48 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Linq;
+using System.Reflection;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.Core.Sources;
+
+namespace ExtendedXmlSerialization.ContentModel.Content
+{
+	sealed class SerializerSelector : Selector<TypeInfo, ISerializer>
+	{
+		readonly IParameterizedSource<TypeInfo, ISerializer> _content;
+
+		public SerializerSelector(params ContainerDefinition[] definitions)
+			: this(
+				new Selector<TypeInfo, ISerializer>(definitions.Select(x => x.Content).ToArray()).Cache(), definitions) {}
+
+		public SerializerSelector(IParameterizedSource<TypeInfo, ISerializer> content,
+		                          params ContainerDefinition[] definitions)
+			: base(definitions.Select(x => new ContainerOption(x.Element, x.Content)).ToArray())
+		{
+			_content = content;
+		}
+
+		public ISerializer Content(TypeInfo parameter) => _content.Get(parameter);
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Content/Serializers.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/Serializers.cs
@@ -1,0 +1,61 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.Core.Specifications;
+
+namespace ExtendedXmlSerialization.ContentModel.Content
+{
+	class Serializers : ISerializers
+	{
+		readonly ISpecification<PropertyInfo> _property;
+		readonly ISpecification<FieldInfo> _field;
+
+		readonly Func<TypeInfo, ISerializer> _selector, _content;
+
+		public Serializers(ISpecification<PropertyInfo> property, ISpecification<FieldInfo> field)
+			: this(property, field, new ContainerDefinitions().Get) {}
+
+		public Serializers(ISpecification<PropertyInfo> property, ISpecification<FieldInfo> field,
+		                   Func<ISerializers, IEnumerable<ContainerDefinition>> definitions)
+		{
+			_property = property;
+			_field = field;
+
+			var selector = new SerializerSelector(definitions(this).ToArray());
+			_selector = selector.Cache().Get;
+			_content = selector.Content;
+		}
+
+		public ISerializer Get(TypeInfo parameter) => _selector(parameter);
+		public ISerializer Content(TypeInfo parameter) => _content(parameter);
+
+		public bool IsSatisfiedBy(PropertyInfo parameter) => _property.IsSatisfiedBy(parameter);
+
+		public bool IsSatisfiedBy(FieldInfo parameter) => _field.IsSatisfiedBy(parameter);
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/IIdentities.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/IIdentities.cs
@@ -21,10 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Reflection;
-using ExtendedXmlSerialization.Core.Sources;
-
-namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
+namespace ExtendedXmlSerialization.ContentModel
 {
-	public interface IIdentities : IParameterizedSource<TypeInfo, string> {}
+	public interface IIdentities
+	{
+		IIdentity Get(string name, string identifier);
+	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/IIdentity.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/IIdentity.cs
@@ -21,29 +21,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
-using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core;
-using ExtendedXmlSerialization.TypeModel;
-
-namespace ExtendedXmlSerialization.ContentModel.Collections
+namespace ExtendedXmlSerialization.ContentModel
 {
-	class ArrayReader : CollectionReader
+	public interface IIdentity
 	{
-		readonly static AddDelegates Add = AddDelegates.Default;
-
-		public ArrayReader(ISerializer item) : this(item, Add) {}
-
-		public ArrayReader(ISerializer item, IAddDelegates add) : base(Activator<ArrayList>.Default, item, add)
-		{
-		}
-
-		public override object Get(IXmlReader parameter)
-		{
-			var elementType = parameter.Classification.GetElementType();
-			var list = base.Get(parameter).AsValid<ArrayList>();
-			var result = list.ToArray(elementType);
-			return result;
-		}
+		string Identifier { get; }
+		string Name { get; }
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Identities.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Identities.cs
@@ -21,18 +21,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using Sprache;
+using System;
+using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml.Parsing
+namespace ExtendedXmlSerialization.ContentModel
 {
-	static class Parsing
+	class Identities : Cache<string, Func<string, IIdentity>>, IIdentities
 	{
-		readonly public static Parser<char>
-			Namespace = Parse.Char(':'),
-			List = Parse.Char(',').Token(),
-			Start = Parse.Char('[').Token(),
-			Finish = Parse.Char(']').Token();
+		public static Identities Default { get; } = new Identities();
+		Identities() : base(i => new Names(i).Get) {}
 
-		public static Parser<string> Identifier { get; } = Xml.Parsing.Identifier.Default.Get();
+		public IIdentity Get(string name, string identifier) => Get(identifier).Invoke(name);
+
+		class Names : CacheBase<string, IIdentity>
+		{
+			readonly string _identifier;
+
+			public Names(string identifier)
+			{
+				_identifier = identifier;
+			}
+
+			protected override IIdentity Create(string parameter) => new Identity(parameter, _identifier);
+		}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Identity.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Identity.cs
@@ -21,20 +21,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Xml.Linq;
-using ExtendedXmlSerialization.Core.Specifications;
+using System;
+using ExtendedXmlSerialization.ContentModel.Xml;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml
+namespace ExtendedXmlSerialization.ContentModel
 {
-	class ContainsNameSpecification : ISpecification<IXmlReader>
+	class Identity : IIdentity, IEquatable<IIdentity>
 	{
-		readonly XName _name;
+		readonly static IdentityComparer IdentityComparer = IdentityComparer.Default;
+		readonly int _code;
 
-		public ContainsNameSpecification(XName name)
+		public Identity(string name, string identifier)
 		{
-			_name = name;
+			Name = name;
+			Identifier = identifier;
+			_code = IdentityComparer.GetHashCode(this);
 		}
 
-		public bool IsSatisfiedBy(IXmlReader parameter) => parameter.Contains(_name);
+		public string Name { get; }
+		public string Identifier { get; }
+
+		public static bool operator ==(Identity left, Identity right) => left._code == right._code;
+		public static bool operator !=(Identity left, Identity right) => left._code != right._code;
+		public bool Equals(IIdentity other) => _code == other.GetHashCode();
+		public override int GetHashCode() => _code;
+		public override bool Equals(object obj) => obj is IIdentity && Equals((IIdentity) obj);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/IdentityFormatter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/IdentityFormatter.cs
@@ -26,10 +26,16 @@ using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel
 {
+	class IdentityFormatter : IdentityFormatter<IIdentity>
+	{
+		public new static IdentityFormatter Default { get; } = new IdentityFormatter();
+		IdentityFormatter() {}
+	}
+
 	class IdentityFormatter<T> : IFormatter<T> where T : IIdentity
 	{
 		public static IdentityFormatter<T> Default { get; } = new IdentityFormatter<T>();
-		IdentityFormatter() {}
+		protected IdentityFormatter() {}
 
 		public string Get(T parameter) => XmlQualifiedName.ToString(parameter.Name, parameter.Identifier);
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/IdentityFormatter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/IdentityFormatter.cs
@@ -21,29 +21,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
-using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core;
-using ExtendedXmlSerialization.TypeModel;
+using System.Xml;
+using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.ContentModel.Collections
+namespace ExtendedXmlSerialization.ContentModel
 {
-	class ArrayReader : CollectionReader
+	class IdentityFormatter<T> : IFormatter<T> where T : IIdentity
 	{
-		readonly static AddDelegates Add = AddDelegates.Default;
+		public static IdentityFormatter<T> Default { get; } = new IdentityFormatter<T>();
+		IdentityFormatter() {}
 
-		public ArrayReader(ISerializer item) : this(item, Add) {}
-
-		public ArrayReader(ISerializer item, IAddDelegates add) : base(Activator<ArrayList>.Default, item, add)
-		{
-		}
-
-		public override object Get(IXmlReader parameter)
-		{
-			var elementType = parameter.Classification.GetElementType();
-			var list = base.Get(parameter).AsValid<ArrayList>();
-			var result = list.ToArray(elementType);
-			return result;
-		}
+		public string Get(T parameter) => XmlQualifiedName.ToString(parameter.Name, parameter.Identifier);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Members/AssignableMemberSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/AssignableMemberSpecification.cs
@@ -25,7 +25,7 @@ using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
 {
-	class AssignableMemberSpecification : DelegatedSpecification<MemberInformation>
+	class AssignableMemberSpecification : DelegatedSpecification<MemberInformation>, IMemberSpecification
 	{
 		public static AssignableMemberSpecification Default { get; } = new AssignableMemberSpecification();
 		AssignableMemberSpecification() : base(x => x.Assignable) {}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/BlacklistMemberPolicy.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/BlacklistMemberPolicy.cs
@@ -1,0 +1,56 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Reflection;
+using ExtendedXmlSerialization.TypeModel;
+
+namespace ExtendedXmlSerialization.ContentModel.Members
+{
+	class BlacklistMemberPolicy : IMemberPolicy
+	{
+		readonly static MemberComparer Comparer = MemberComparer.Default;
+
+		readonly ICollection<MemberInfo> _avoid;
+
+		public BlacklistMemberPolicy(params MemberInfo[] avoid) : this(Comparer, avoid) {}
+
+		public BlacklistMemberPolicy(IMemberComparer comparer, params MemberInfo[] avoid)
+			: this(new HashSet<MemberInfo>(avoid, comparer)) {}
+
+		public BlacklistMemberPolicy(ICollection<MemberInfo> avoid)
+		{
+			_avoid = avoid;
+		}
+
+		public bool IsSatisfiedBy(MemberInfo parameter) => !_avoid.Contains(parameter);
+	}
+
+	/*class MemberPolicy : IMemberPolicy
+	{
+		public static MemberPolicy Default { get; } = new MemberPolicy();
+		MemberPolicy() {}
+
+		public bool IsSatisfiedBy(MemberInfo parameter) => true;
+	}*/
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/IMemberPolicy.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/IMemberPolicy.cs
@@ -21,22 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using ExtendedXmlSerialization.ContentModel.Xml;
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Specifications;
 
-namespace ExtendedXmlSerialization.ContentModel
+namespace ExtendedXmlSerialization.ContentModel.Members
 {
-	class DecoratedSerializer : SerializerBase
-	{
-		readonly IReader _reader;
-		readonly IWriter _writer;
-
-		public DecoratedSerializer(IReader reader, IWriter writer)
-		{
-			_reader = reader;
-			_writer = writer;
-		}
-
-		public override void Write(IXmlWriter writer, object instance) => _writer.Write(writer, instance);
-		public override object Get(IXmlReader reader) => _reader.Get(reader);
-	}
+	public interface IMemberPolicy : ISpecification<MemberInfo> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Members/IMemberSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/IMemberSpecification.cs
@@ -1,0 +1,29 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using ExtendedXmlSerialization.Core.Specifications;
+
+namespace ExtendedXmlSerialization.ContentModel.Members
+{
+	public interface IMemberSpecification : ISpecification<MemberInformation> {}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/Member.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/Member.cs
@@ -23,24 +23,38 @@
 
 using System;
 using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
 {
 	class Member : Container, IMember
 	{
+		readonly ISpecification<object> _emit;
 		readonly Action<object, object> _setter;
 		readonly Func<object, object> _getter;
 
-		public Member(string displayName, Func<object, object> getter, Action<object, object> setter, ISerializer body)
-			: this(displayName, getter, setter, new Content.Member(displayName), body) {}
+		public Member(ISpecification<object> emit, string displayName, Func<object, object> getter,
+		              Action<object, object> setter, ISerializer body)
+			: this(emit, displayName, getter, setter, new Content.Member(displayName), body) {}
 
-		protected Member(string displayName, Func<object, object> getter, Action<object, object> setter, IWriter element,
-		                 ISerializer body)
-			: base(element, body)
+		protected Member(ISpecification<object> emit, string displayName, Func<object, object> getter,
+		                 Action<object, object> setter, IWriter element,
+		                 ISerializer content) : base(element, content)
 		{
 			DisplayName = displayName;
+			_emit = emit;
 			_setter = setter;
 			_getter = getter;
+		}
+
+		public override void Write(IXmlWriter writer, object instance)
+		{
+			var value = Get(instance);
+			if (_emit.IsSatisfiedBy(value))
+			{
+				base.Write(writer, value);
+			}
 		}
 
 

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberAliases.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberAliases.cs
@@ -32,7 +32,7 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 		public static MemberAliases Default { get; } = new MemberAliases();
 		MemberAliases() {}
 
-		protected override string Create(MemberInfo parameter)
+		public override string Get(MemberInfo parameter)
 		{
 			return parameter.GetCustomAttribute<XmlAttributeAttribute>(false)?.AttributeName.NullIfEmpty() ??
 			       parameter.GetCustomAttribute<XmlElementAttribute>(false)?.ElementName.NullIfEmpty();

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberContentsReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberContentsReader.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
-using System.Reflection;
+using System.Collections.Generic;
+using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.Core;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Members
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	class MemberContentsReader : IContentsReader
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
+		readonly IDictionary<string, IMember> _members;
 
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
+		public MemberContentsReader(IDictionary<string, IMember> members)
 		{
-			_interfaces = interfaces;
-			_identity = identity;
+			_members = members;
 		}
 
-		public bool Equals(TypeInfo x, TypeInfo y)
+		public void Read(IXmlReader reader, object instance)
 		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
+			var member = _members.Get(reader.Name);
+			member?.Assign(instance, ((IReader) member).Get(reader));
 		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberOption.cs
@@ -33,24 +33,24 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 	{
 		readonly ISetterFactory _setter;
 
-		public MemberOption(IContainers containers)
-			: this(AssignableMemberSpecification.Default, containers) {}
+		public MemberOption(ISerializers serializers)
+			: this(AssignableMemberSpecification.Default, serializers) {}
 
-		public MemberOption(ISpecification<MemberInformation> specification, IContainers containers)
-			: this(specification, containers, SetterFactory.Default) {}
+		public MemberOption(IMemberSpecification specification, ISerializers serializers)
+			: this(specification, serializers, SetterFactory.Default) {}
 
-		public MemberOption(ISpecification<MemberInformation> specification, IContainers containers, ISetterFactory setter)
-			: base(specification, containers)
+		public MemberOption(IMemberSpecification specification, ISerializers serializers, ISetterFactory setter)
+			: base(specification, serializers)
 		{
 			_setter = setter;
 		}
 
-		protected override IMember Create(string displayName, TypeInfo classification, Func<object, object> getter,
-		                                  ISerializer body, MemberInfo metadata)
+		protected override IMember Create(ISpecification<object> emit, string displayName, TypeInfo classification,
+		                                  Func<object, object> getter, ISerializer body, MemberInfo metadata)
 			=> CreateMember(displayName, classification, _setter.Get(metadata), getter, body);
 
 		protected virtual IMember CreateMember(string displayName, TypeInfo classification, Action<object, object> setter,
 		                                       Func<object, object> getter, ISerializer body)
-			=> new Member(displayName, getter, setter, body);
+			=> new Member(AssignedSpecification.Default, displayName, getter, setter, body);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberOptionBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberOptionBase.cs
@@ -32,19 +32,17 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 {
 	public abstract class MemberOptionBase : OptionBase<MemberInformation, IMember>, IMemberOption
 	{
-		readonly IContainers _containers;
+		readonly ISerializers _serializers;
 		readonly IAliases<MemberInfo> _alias;
 		readonly IGetterFactory _getter;
 
-		protected MemberOptionBase(ISpecification<MemberInformation> specification, IContainers containers)
-			: this(specification, containers, MemberAliases.Default, GetterFactory.Default) {}
+		protected MemberOptionBase(IMemberSpecification specification, ISerializers serializers)
+			: this(specification, serializers, MemberAliases.Default, GetterFactory.Default) {}
 
-		protected MemberOptionBase(ISpecification<MemberInformation> specification, IContainers containers,
-		                           IAliases<MemberInfo> alias, IGetterFactory getter
-		)
-			: base(specification)
+		protected MemberOptionBase(IMemberSpecification specification, ISerializers serializers, IAliases<MemberInfo> alias,
+		                           IGetterFactory getter) : base(specification)
 		{
-			_containers = containers;
+			_serializers = serializers;
 			_alias = alias;
 			_getter = getter;
 		}
@@ -52,13 +50,14 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 		public override IMember Get(MemberInformation parameter)
 		{
 			var getter = _getter.Get(parameter.Metadata);
-			var body = _containers.Content(parameter.MemberType);
-			var result = Create(_alias.Get(parameter.Metadata) ?? parameter.Metadata.Name, parameter.MemberType, getter, body,
-			                    parameter.Metadata);
+			var body = _serializers.Content(parameter.MemberType);
+			var result = Create(AssignedSpecification.Default, _alias.Get(parameter.Metadata) ?? parameter.Metadata.Name,
+			                    parameter.MemberType, getter, body, parameter.Metadata);
 			return result;
 		}
 
-		protected abstract IMember Create(string displayName, TypeInfo classification, Func<object, object> getter,
+		protected abstract IMember Create(ISpecification<object> emit, string displayName, TypeInfo classification,
+		                                  Func<object, object> getter,
 		                                  ISerializer body, MemberInfo metadata);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberTypeSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberTypeSpecification.cs
@@ -1,0 +1,40 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Specifications;
+
+namespace ExtendedXmlSerialization.ContentModel.Members
+{
+	class MemberTypeSpecification : IMemberSpecification
+	{
+		readonly ISpecification<TypeInfo> _specification;
+
+		public MemberTypeSpecification(ISpecification<TypeInfo> specification)
+		{
+			_specification = specification;
+		}
+
+		public bool IsSatisfiedBy(MemberInformation parameter) => _specification.IsSatisfiedBy(parameter.MemberType);
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberWriter.cs
@@ -40,12 +40,7 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 			var length = _members.Length;
 			for (var i = 0; i < length; i++)
 			{
-				var member = _members[i];
-				var value = member.Get(instance);
-				if (value != null)
-				{
-					member.Write(writer, value);
-				}
+				_members[i].Write(writer, instance);
 			}
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberedContentOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberedContentOption.cs
@@ -21,11 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using ExtendedXmlSerialization.ContentModel.Content;
-using ExtendedXmlSerialization.Core.Sources;
 using ExtendedXmlSerialization.TypeModel;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
@@ -33,11 +31,11 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 	class MemberedContentOption : ContentOptionBase
 	{
 		readonly IActivators _activators;
-		readonly IParameterizedSource<TypeInfo, ImmutableArray<IMember>> _members;
+		readonly IMembers _members;
 
-		public MemberedContentOption(ISelector selector) : this(Activators.Default, new Members(selector)) {}
+		public MemberedContentOption(IMembers members) : this(Activators.Default, members) {}
 
-		public MemberedContentOption(IActivators activators, IParameterizedSource<TypeInfo, ImmutableArray<IMember>> members)
+		public MemberedContentOption(IActivators activators, IMembers members)
 			: base(IsActivatedTypeSpecification.Default)
 		{
 			_activators = activators;
@@ -49,7 +47,7 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 			var members = _members.Get(parameter);
 			var activate = _activators.Get(parameter.AsType());
 			var reader = new MemberedReader(new DelegatedFixedActivator(activate), members.ToDictionary(x => x.DisplayName));
-			var result = new DecoratedSerializer(reader, new MemberWriter(members));
+			var result = new Serializer(reader, new MemberWriter(members));
 			return result;
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/MemberedContentOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/MemberedContentOption.cs
@@ -46,7 +46,9 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 		{
 			var members = _members.Get(parameter);
 			var activate = _activators.Get(parameter.AsType());
-			var reader = new MemberedReader(new DelegatedFixedActivator(activate), members.ToDictionary(x => x.DisplayName));
+			var reader = new ActivatedContentsReader(new DelegatedFixedActivator(activate),
+			                                         new ContentsReader(
+				                                         new MemberContentsReader(members.ToDictionary(x => x.DisplayName))));
 			var result = new Serializer(reader, new MemberWriter(members));
 			return result;
 		}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/Members.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/Members.cs
@@ -24,6 +24,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Content;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
@@ -32,7 +33,7 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 	{
 		readonly IParameterizedSource<TypeInfo, IEnumerable<IMember>> _source;
 
-		public Members(ISelector selector) : this(new MemberSource(selector)) {}
+		public Members(ISerializers serializers, ISelector selector) : this(new MemberSource(serializers, selector)) {}
 
 		public Members(IParameterizedSource<TypeInfo, IEnumerable<IMember>> source)
 		{

--- a/src/ExtendedXmlSerializer/ContentModel/Members/Selector.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/Selector.cs
@@ -28,9 +28,9 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 {
 	class Selector : Selector<MemberInformation, IMember>, ISelector
 	{
-		public Selector(IContainers containers) : this(containers, new VariableTypeMemberOption(containers)) {}
+		public Selector(ISerializers serializers) : this(serializers, new VariableTypeMemberOption(serializers)) {}
 
-		public Selector(IContainers containers, IMemberOption variable)
-			: base(variable, new MemberOption(containers), new ReadOnlyCollectionMemberOption(containers)) {}
+		public Selector(ISerializers serializers, IMemberOption variable)
+			: base(variable, new MemberOption(serializers), new ReadOnlyCollectionMemberOption(serializers)) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMember.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMember.cs
@@ -22,9 +22,7 @@
 // SOFTWARE.
 
 using System;
-using System.Reflection;
 using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
@@ -33,9 +31,6 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 	{
 		readonly IMember _member;
 		readonly ISpecification<Type> _specification;
-
-		public VariableTypeMember(TypeInfo classification, IMember member)
-			: this(new EqualitySpecification<Type>(classification.AsType()).Inverse(), member) {}
 
 		public VariableTypeMember(ISpecification<Type> specification, IMember member)
 		{

--- a/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMemberOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMemberOption.cs
@@ -33,10 +33,10 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 	{
 		readonly ISerializer _runtime;
 
-		public VariableTypeMemberOption(IContainers containers) : this(containers, new RuntimeSerializer(containers)) {}
+		public VariableTypeMemberOption(ISerializers serializers) : this(serializers, new RuntimeSerializer(serializers)) {}
 
-		public VariableTypeMemberOption(IContainers containers, ISerializer runtime)
-			: base(VariableTypeMemberSpecification.Default, containers)
+		public VariableTypeMemberOption(ISerializers serializers, ISerializer runtime)
+			: base(VariableTypeMemberSpecification.Default, serializers)
 		{
 			_runtime = runtime;
 		}
@@ -45,7 +45,7 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 		                                        Func<object, object> getter, ISerializer body)
 		{
 			var specification = new EqualitySpecification<Type>(classification.AsType()).Inverse();
-			var converter = new DecoratedSerializer(body, new VariableTypeWriter(specification, _runtime, body));
+			var converter = new Serializer(body, new VariableTypeWriter(specification, _runtime, body));
 			var member = base.CreateMember(displayName, classification, setter, getter, converter);
 			var result = new VariableTypeMember(specification, member);
 			return result;

--- a/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMemberSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMemberSpecification.cs
@@ -27,7 +27,7 @@ using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
 {
-	class VariableTypeMemberSpecification : DecoratedSpecification<MemberInformation>
+	class VariableTypeMemberSpecification : DecoratedSpecification<MemberInformation>, IMemberSpecification
 	{
 		public static VariableTypeMemberSpecification Default { get; } = new VariableTypeMemberSpecification();
 		VariableTypeMemberSpecification() : this(FixedTypeSpecification.Default.Inverse()) {}

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/Defaults.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/Defaults.cs
@@ -29,6 +29,7 @@ namespace ExtendedXmlSerialization.ContentModel.Properties
 	static class Defaults
 	{
 		readonly static TypeInfo Type = ContentModel.Defaults.FrameworkType;
-		public static string Namespace { get; } = Identities.Default.Get(Type);
+
+		public static string Namespace { get; } = Identifiers.Default.Get(Type);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/IProperty.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/IProperty.cs
@@ -21,9 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using ExtendedXmlSerialization.ContentModel.Xml;
-
 namespace ExtendedXmlSerialization.ContentModel.Properties
 {
-	public interface IProperty<T> : ISerializer<T>, IEntity {}
+	public interface IProperty<T> : ISerializer<T>, IIdentity {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/NameConverter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/NameConverter.cs
@@ -23,34 +23,35 @@
 
 using System;
 using System.Linq;
-using System.Xml;
 using ExtendedXmlSerialization.ContentModel.Converters;
 using ExtendedXmlSerialization.ContentModel.Xml.Parsing;
-using Sprache;
+using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Properties
 {
 	class NameConverter : ConverterBase<ParsedName>, INameConverter
 	{
 		public static NameConverter Default { get; } = new NameConverter();
-		NameConverter() : this(Parser.Default) {}
+		NameConverter() : this(IdentityFormatter<ParsedName>.Default, ParsedNames.Default) {}
 
-		readonly Parser<ParsedName> _parser;
+		readonly IFormatter<ParsedName> _formatter;
+		readonly IParsedNames _names;
 		readonly Func<ParsedName, string> _selector;
 
-		public NameConverter(Parser<ParsedName> parser)
+		public NameConverter(IFormatter<ParsedName> formatter, IParsedNames names)
 		{
-			_parser = parser;
+			_formatter = formatter;
+			_names = names;
 			_selector = Format;
 		}
 
-		public override ParsedName Parse(string data) => _parser.Parse(data);
+		public override ParsedName Parse(string data) => _names.Get(data);
 
 		public override string Format(ParsedName instance)
 		{
 			var arguments = instance.GetArguments();
 			var append = arguments.HasValue ? $"[{string.Join(",", arguments.Value.Select(_selector))}]" : null;
-			var result = $"{XmlQualifiedName.ToString(instance.Identity.Name, instance.Identity.Identifier)}{append}";
+			var result = $"{_formatter.Get(instance)}{append}";
 			return result;
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/PropertyBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/PropertyBase.cs
@@ -21,29 +21,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Xml.Linq;
 using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
 
 namespace ExtendedXmlSerialization.ContentModel.Properties
 {
-	abstract class PropertyBase<T> : IProperty<T>
+	abstract class PropertyBase<T> : Identity, IProperty<T>
 	{
-		protected PropertyBase(string displayName) : this(XName.Get(displayName, Defaults.Namespace)) {}
+		protected PropertyBase(string name) : this(name, Defaults.Namespace) {}
 
-		protected PropertyBase(XName name)
-		{
-			Name = name;
-		}
+		protected PropertyBase(string name, string identifier) : base(name, identifier) {}
 
-		public XName Name { get; }
-
-		public virtual T Get(IXmlReader parameter) => Parse(parameter, parameter[Name]);
+		public virtual T Get(IXmlReader parameter) => Parse(parameter, parameter.Value());
 		protected abstract T Parse(IXmlReader parameter, string data);
 
 		public virtual void Write(IXmlWriter writer, T instance)
 		{
-			var format = Format(writer, instance);
-			writer.Attribute(Name, format);
+			var identifier = Format(writer, instance);
+			var ns = new Namespace(writer.Get(Identifier), Identifier);
+			var attribute = new Attribute(Name, identifier, ns);
+			writer.Attribute(attribute);
 		}
 
 		protected abstract string Format(IXmlWriter writer, T instance);

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/TypeFormatter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/TypeFormatter.cs
@@ -32,19 +32,19 @@ namespace ExtendedXmlSerialization.ContentModel.Properties
 {
 	class TypeFormatter : ITypeFormatter
 	{
-		readonly static Names Names = Names.Default;
+		readonly static Xml.Identities Identities = Xml.Identities.Default;
 		readonly static NameConverter Converter = NameConverter.Default;
 
 		readonly IXmlWriter _writer;
-		readonly INames _names;
+		readonly Xml.IIdentities _identities;
 		readonly INameConverter _converter;
 
-		public TypeFormatter(IXmlWriter writer) : this(writer, Names, Converter) {}
+		public TypeFormatter(IXmlWriter writer) : this(writer, Identities, Converter) {}
 
-		public TypeFormatter(IXmlWriter writer, INames names, INameConverter converter)
+		public TypeFormatter(IXmlWriter writer, Xml.IIdentities identities, INameConverter converter)
 		{
 			_writer = writer;
-			_names = names;
+			_identities = identities;
 			_converter = converter;
 		}
 
@@ -52,12 +52,10 @@ namespace ExtendedXmlSerialization.ContentModel.Properties
 
 		ParsedName Name(TypeInfo parameter)
 		{
-			var name = _names.Get(parameter);
-			var parsed = new ParsedName(
-				new Identity(name.LocalName, _writer.Get(name.NamespaceName)),
-				parameter.IsGenericType ? Arguments(parameter.GetGenericArguments()) : null
-			);
-			return parsed;
+			var identity = _identities.Get(parameter);
+			var result = new ParsedName(identity.Name, _writer.Get(identity.Identifier),
+			                            parameter.IsGenericType ? Arguments(parameter.GetGenericArguments()) : null);
+			return result;
 		}
 
 		Func<ImmutableArray<ParsedName>> Arguments(Type[] types)

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/TypeParser.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/TypeParser.cs
@@ -31,16 +31,16 @@ namespace ExtendedXmlSerialization.ContentModel.Properties
 {
 	class TypeParser : ITypeParser
 	{
-		readonly static Types Types = Types.Default;
-		readonly static NameConverter Converter = NameConverter.Default;
 		readonly static Identities Identities = Identities.Default;
+		readonly static GenericTypes GenericTypes = GenericTypes.Default;
+		readonly static NameConverter Converter = NameConverter.Default;
 
 		readonly IIdentities _identities;
 		readonly ITypes _types;
 		readonly INameConverter _converter;
 		readonly IXmlReader _reader;
 
-		public TypeParser(IXmlReader reader) : this(Identities, Types, Converter, reader) {}
+		public TypeParser(IXmlReader reader) : this(Identities, GenericTypes, Converter, reader) {}
 
 		public TypeParser(IIdentities identities, ITypes types, INameConverter converter, IXmlReader reader)
 		{

--- a/src/ExtendedXmlSerializer/ContentModel/Properties/TypeParser.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Properties/TypeParser.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Collections.Immutable;
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.ContentModel.Xml.Parsing;
 
@@ -34,15 +33,18 @@ namespace ExtendedXmlSerialization.ContentModel.Properties
 	{
 		readonly static Types Types = Types.Default;
 		readonly static NameConverter Converter = NameConverter.Default;
+		readonly static Identities Identities = Identities.Default;
 
+		readonly IIdentities _identities;
 		readonly ITypes _types;
 		readonly INameConverter _converter;
 		readonly IXmlReader _reader;
 
-		public TypeParser(IXmlReader reader) : this(Types, Converter, reader) {}
+		public TypeParser(IXmlReader reader) : this(Identities, Types, Converter, reader) {}
 
-		public TypeParser(ITypes types, INameConverter converter, IXmlReader reader)
+		public TypeParser(IIdentities identities, ITypes types, INameConverter converter, IXmlReader reader)
 		{
+			_identities = identities;
 			_types = types;
 			_converter = converter;
 			_reader = reader;
@@ -57,9 +59,8 @@ namespace ExtendedXmlSerialization.ContentModel.Properties
 
 		public TypeInfo Get(ParsedName name)
 		{
-			var identity = name.Identity;
-			var key = XName.Get(identity.Name, _reader.Get(identity.Identifier).NamespaceName);
-			var typeInfo = _types.Get(key);
+			var identity = _identities.Get(name.Name, _reader.Get(name.Identifier));
+			var typeInfo = _types.Get(identity);
 			var arguments = name.GetArguments();
 			var result = arguments.HasValue ? typeInfo.MakeGenericType(Arguments(arguments.Value)).GetTypeInfo() : typeInfo;
 			return result;

--- a/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
@@ -29,17 +29,16 @@ namespace ExtendedXmlSerialization.ContentModel
 {
 	sealed class RuntimeSerializer : SerializerBase
 	{
-		
-		readonly IContainers _containers;
+		readonly ISerializers _serializers;
 
-		public RuntimeSerializer(IContainers containers)
+		public RuntimeSerializer(ISerializers serializers)
 		{
-			_containers = containers;
+			_serializers = serializers;
 		}
 
 		public override void Write(IXmlWriter writer, object instance)
-			=> _containers.Content(instance.GetType().GetTypeInfo()).Write(writer, instance);
+			=> _serializers.Content(instance.GetType().GetTypeInfo()).Write(writer, instance);
 
-		public override object Get(IXmlReader reader) => _containers.Content(reader.Classification).Get(reader);
+		public override object Get(IXmlReader reader) => _serializers.Content(reader.Classification).Get(reader);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
@@ -29,22 +29,17 @@ namespace ExtendedXmlSerialization.ContentModel
 {
 	sealed class RuntimeSerializer : SerializerBase
 	{
-		readonly static TypeSelector Selector = TypeSelector.Default;
-
-		readonly ITypeSelector _selector;
+		
 		readonly IContainers _containers;
 
-		public RuntimeSerializer(IContainers containers) : this(Selector, containers) {}
-
-		public RuntimeSerializer(ITypeSelector selector, IContainers containers)
+		public RuntimeSerializer(IContainers containers)
 		{
-			_selector = selector;
 			_containers = containers;
 		}
 
 		public override void Write(IXmlWriter writer, object instance)
 			=> _containers.Content(instance.GetType().GetTypeInfo()).Write(writer, instance);
 
-		public override object Get(IXmlReader reader) => _containers.Content(_selector.Get(reader)).Get(reader);
+		public override object Get(IXmlReader reader) => _containers.Content(reader.Classification).Get(reader);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
@@ -29,16 +29,28 @@ namespace ExtendedXmlSerialization.ContentModel
 {
 	sealed class RuntimeSerializer : SerializerBase
 	{
+		readonly static TypeSelector TypeSelector = TypeSelector.Default;
+
+		readonly ITypeSelector _selector;
 		readonly ISerializers _serializers;
 
-		public RuntimeSerializer(ISerializers serializers)
+		public RuntimeSerializer(ISerializers serializers) : this(TypeSelector, serializers) {}
+
+		public RuntimeSerializer(ITypeSelector selector, ISerializers serializers)
 		{
+			_selector = selector;
 			_serializers = serializers;
 		}
 
 		public override void Write(IXmlWriter writer, object instance)
 			=> _serializers.Content(instance.GetType().GetTypeInfo()).Write(writer, instance);
 
-		public override object Get(IXmlReader reader) => _serializers.Content(reader.Classification).Get(reader);
+		public override object Get(IXmlReader reader)
+		{
+			var classification = _selector.Get(reader);
+			var content = _serializers.Content(classification);
+			var result = content.Get(reader);
+			return result;
+		}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/SelectingWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/SelectingWriter.cs
@@ -1,0 +1,40 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.Core.Sources;
+
+namespace ExtendedXmlSerialization.ContentModel
+{
+	class SelectingWriter : IWriter
+	{
+		readonly ISelector<object, IWriter> _selector;
+
+		public SelectingWriter(ISelector<object, IWriter> selector)
+		{
+			_selector = selector;
+		}
+
+		public void Write(IXmlWriter writer, object instance) => _selector.Get(instance)?.Write(writer, instance);
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Serializer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Serializer.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,28 +21,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.ContentModel.Xml;
 
-namespace ExtendedXmlSerialization.ContentModel.Content
+namespace ExtendedXmlSerialization.ContentModel
 {
-	class Containers : IContainers
+	class Serializer : SerializerBase
 	{
-		readonly Func<TypeInfo, ISerializer> _selector, _content;
+		readonly IReader _reader;
+		readonly IWriter _writer;
 
-		public Containers() : this(new ContainerDefinitions().Get) {}
-
-		public Containers(Func<IContainers, IEnumerable<ContainerDefinition>> definitions)
+		public Serializer(IReader reader, IWriter writer)
 		{
-			var selector = new ContainerSelector(definitions(this).ToArray());
-			_selector = selector.Cache().Get;
-			_content = selector.Content;
+			_reader = reader;
+			_writer = writer;
 		}
 
-		public ISerializer Get(TypeInfo parameter) => _selector(parameter);
-		public ISerializer Content(TypeInfo parameter) => _content(parameter);
+		public override void Write(IXmlWriter writer, object instance) => _writer.Write(writer, instance);
+		public override object Get(IXmlReader reader) => _reader.Get(reader);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/AssemblyPartitionedTypes.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/AssemblyPartitionedTypes.cs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core.Sources;
 using ExtendedXmlSerialization.TypeModel;
 using Sprache;
@@ -50,16 +49,16 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			_names = names;
 		}
 
-		public TypeInfo Get(XName parameter)
+		public TypeInfo Get(IIdentity parameter)
 		{
-			var parse = _parser.Get().TryParse(parameter.NamespaceName);
+			var parse = _parser.Get().TryParse(parameter.Identifier);
 			if (parse.WasSuccessful)
 			{
 				var assembly = _loader.Get(parse.Value.Path);
 
 				var result =
-					assembly.GetType($"{parse.Value.Namespace}.{_names.Get(parameter.LocalName)}", false, false)?.GetTypeInfo() ??
-					_partitions.Get(assembly)?.Invoke(parse.Value.Namespace)?.Invoke(parameter.LocalName);
+					assembly.GetType($"{parse.Value.Namespace}.{_names.Get(parameter.Name)}", false, false)?.GetTypeInfo() ??
+					_partitions.Get(assembly)?.Invoke(parse.Value.Namespace)?.Invoke(parameter.Name);
 				return result;
 			}
 			return null;

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/ContainsSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/ContainsSpecification.cs
@@ -21,31 +21,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Reflection;
-using System.Xml.Linq;
-using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
-using ExtendedXmlSerialization.Core.Sources;
-using ExtendedXmlSerialization.TypeModel;
+using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class Names : ReferenceCacheBase<TypeInfo, XName>, INames
+	class ContainsSpecification : ISpecification<IXmlReader>
 	{
-		public static Names Default { get; } = new Names();
-		Names() : this(TypeAliases.Default, ContentModel.TypeFormatter.Default, Identities.Default) {}
+		readonly IIdentity _identity;
 
-		readonly IAliases _alias;
-		readonly ITypeFormatter _formatter;
-		readonly IIdentities _identities;
-
-		public Names(IAliases alias, ITypeFormatter formatter, IIdentities identities)
+		public ContainsSpecification(IIdentity identity)
 		{
-			_alias = alias;
-			_formatter = formatter;
-			_identities = identities;
+			_identity = identity;
 		}
 
-		protected override XName Create(TypeInfo parameter)
-			=> XName.Get(_alias.Get(parameter) ?? _formatter.Get(parameter), _identities.Get(parameter));
+		public bool IsSatisfiedBy(IXmlReader parameter) => parameter.Contains(_identity);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/GenericTypeOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/GenericTypeOption.cs
@@ -34,7 +34,7 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 
 		readonly IArgumentsProperty _property;
 
-		public GenericTypeOption(IArgumentsProperty property) : base(new ContainsNameSpecification(property.Name))
+		public GenericTypeOption(IArgumentsProperty property) : base(new ContainsSpecification(property))
 		{
 			_property = property;
 		}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/GenericTypeOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/GenericTypeOption.cs
@@ -34,7 +34,8 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 
 		readonly IArgumentsProperty _property;
 
-		public GenericTypeOption(IArgumentsProperty property) : base(new ContainsSpecification(property))
+		public GenericTypeOption(IArgumentsProperty property)
+			: base(new ContainsSpecification(property), GenericTypes.Default)
 		{
 			_property = property;
 		}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/GenericTypes.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/GenericTypes.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
 using System.Reflection;
+using ExtendedXmlSerialization.TypeModel;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	class GenericTypes : Types
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
+		readonly static GenericActivatedTypeSpecification Specification = GenericActivatedTypeSpecification.Default;
 
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
+		public new static GenericTypes Default { get; } = new GenericTypes();
+		GenericTypes() : this(Types.Default) {}
 
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
+		readonly ITypes _types;
+
+		public GenericTypes(ITypes types) : base(Specification, new AssemblyTypePartitions(Specification), TypeLoader.Default)
 		{
-			_interfaces = interfaces;
-			_identity = identity;
+			_types = types;
 		}
 
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		protected override TypeInfo Create(IIdentity parameter) => base.Create(parameter) ?? _types.Get(parameter);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IIdentities.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IIdentities.cs
@@ -21,28 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
 using System.Reflection;
-using ExtendedXmlSerialization.Core;
-using ExtendedXmlSerialization.TypeModel;
+using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
+namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class Identities : IIdentities
-	{
-		public static Identities Default { get; } = new Identities();
-		Identities() : this(WellKnownNamespaces.Default, NamespaceFormatter.Default) {}
-
-		readonly IDictionary<Assembly, Namespace> _known;
-		readonly ITypeFormatter _formatter;
-
-		public Identities(IDictionary<Assembly, Namespace> known, ITypeFormatter formatter)
-		{
-			_known = known;
-			_formatter = formatter;
-		}
-
-		public string Get(TypeInfo parameter)
-			=> _known.GetStructure(parameter.Assembly)?.Identity ?? _formatter.Get(parameter);
-	}
+	public interface IIdentities : IParameterizedSource<TypeInfo, IIdentity> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IPrefixAware.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IPrefixAware.cs
@@ -21,10 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	public interface IPrefixAware : IFormatter<XNamespace> {}
+	public interface IPrefixAware : IAlteration<string> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/ITypes.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/ITypes.cs
@@ -22,10 +22,9 @@
 // SOFTWARE.
 
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	public interface ITypes : IParameterizedSource<XName, TypeInfo> {}
+	public interface ITypes : IParameterizedSource<IIdentity, TypeInfo> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IXmlFactory.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IXmlFactory.cs
@@ -21,19 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-namespace ExtendedXmlSerialization.ContentModel.Xml.Parsing
+using System.IO;
+
+namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	struct Identity
+	public interface IXmlFactory
 	{
-		public Identity(string name) : this(name, string.Empty) {}
+		IXmlWriter Create(Stream stream, object instance);
 
-		public Identity(string name, string identifier)
-		{
-			Name = name;
-			Identifier = identifier;
-		}
-
-		public string Name { get; }
-		public string Identifier { get; }
+		IXmlReader Create(Stream stream);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IXmlReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IXmlReader.cs
@@ -23,17 +23,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Xml.Linq;
-using ExtendedXmlSerialization.Core.Sources;
+using System.Reflection;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	public interface IXmlReader : IEntity, IParser<XNamespace>, IDisposable
+	public interface IXmlReader : IPrefixAware, IDisposable
 	{
-		bool Contains(XName name);
+		TypeInfo Classification { get; }
 
-		string this[XName name] { get; }
+		IIdentity Identity { get; }
 
+		bool Contains(IIdentity identity);
 
 		string Value();
 

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IXmlWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IXmlWriter.cs
@@ -22,17 +22,31 @@
 // SOFTWARE.
 
 using System;
-using System.Xml.Linq;
+using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
+	public struct Attribute : IIdentity
+	{
+		public Attribute(string name, string identifier, Namespace? @namespace = null)
+		{
+			Name = name;
+			Identifier = identifier;
+			Namespace = @namespace;
+		}
+
+		public string Name { get; }
+		public string Identifier { get; }
+		public Namespace? Namespace { get; }
+	}
+
 	public interface IXmlWriter : IPrefixAware, IDisposable
 	{
-		void Element(XName name);
+		void Element(IIdentity identity);
 
 		void EndCurrent();
 
-		void Attribute(XName name, string value);
+		void Attribute(Attribute attribute);
 
 		void Write(string text);
 

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Identities.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Identities.cs
@@ -21,32 +21,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using ExtendedXmlSerialization.ContentModel.Content;
-using ExtendedXmlSerialization.ContentModel.Members;
+using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
+using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.TypeModel;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
+namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	public class OptimizedXmlWriterFactory : IXmlWriterFactory
+	class Identities : ReferenceCacheBase<TypeInfo, IIdentity>, IIdentities
 	{
-		readonly IXmlWriterFactory _factory;
-		readonly IObjectNamespaces _namespaces;
+		public static Identities Default { get; } = new Identities();
+		Identities() : this(ContentModel.Identities.Default, TypeAliases.Default, ContentModel.TypeFormatter.Default, Identifiers.Default) {}
 
-		public OptimizedXmlWriterFactory() : this(new Containers()) {}
+		readonly ContentModel.IIdentities _source;
+		readonly IAliases _alias;
+		readonly ITypeFormatter _formatter;
+		readonly IIdentifiers _identifiers;
 
-		public OptimizedXmlWriterFactory(IContainers containers)
-			: this(XmlWriterFactory.Default, new ObjectNamespaces(new Members.Members(new Selector(containers)))) {}
-
-		public OptimizedXmlWriterFactory(IXmlWriterFactory factory, IObjectNamespaces namespaces)
+		public Identities(ContentModel.IIdentities source, IAliases alias, ITypeFormatter formatter, IIdentifiers identifiers)
 		{
-			_factory = factory;
-			_namespaces = namespaces;
+			_source = source;
+			_alias = alias;
+			_formatter = formatter;
+			_identifiers = identifiers;
 		}
 
-		public IXmlWriter Create(System.Xml.XmlWriter writer, object instance)
-		{
-			var origin = _factory.Create(writer, instance);
-			var result = new OptimizedXmlWriter(origin, writer, _namespaces.Get(instance));
-			return result;
-		}
+		protected override IIdentity Create(TypeInfo parameter)
+			=> _source.Get(_alias.Get(parameter) ?? _formatter.Get(parameter), _identifiers.Get(parameter));
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IdentityComparer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IdentityComparer.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace ExtendedXmlSerialization.ContentModel.Xml
+{
+	public class IdentityComparer : IdentityComparer<IIdentity>
+	{
+		public new static IdentityComparer Default { get; } = new IdentityComparer();
+		IdentityComparer() {}
+	}
+
+	public class IdentityComparer<T> : IEqualityComparer<T> where T : IIdentity
+	{
+		public static IdentityComparer<T> Default { get; } = new IdentityComparer<T>();
+		protected IdentityComparer() {}
+
+		public bool Equals(T x, T y)
+			=> ReferenceEquals(x, y) || string.Equals(x.Name, y.Name) && string.Equals(x.Identifier, y.Identifier);
+
+		public int GetHashCode(T obj) => obj.Name.GetHashCode() ^ obj.Identifier.GetHashCode();
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/IdentityPartitionedTypes.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/IdentityPartitionedTypes.cs
@@ -1,0 +1,79 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.Core.Specifications;
+using ExtendedXmlSerialization.TypeModel;
+
+namespace ExtendedXmlSerialization.ContentModel.Xml
+{
+	class IdentityPartitionedTypes : ITypes
+	{
+		public IdentityPartitionedTypes(ISpecification<TypeInfo> specification) : this(specification, TypeFormatter.Default) {}
+
+		public IdentityPartitionedTypes(ISpecification<TypeInfo> specification, ITypeFormatter formatter)
+			: this(WellKnownNamespaces.Default
+			                          .ToDictionary(x => x.Value.Identifier, new TypeNamePartition(specification, formatter).Get)
+			                          .Get) {}
+
+		readonly Partition _partition;
+
+		public IdentityPartitionedTypes(Partition partition)
+		{
+			_partition = partition;
+		}
+
+		public TypeInfo Get(IIdentity parameter) => _partition.Invoke(parameter.Identifier)?.Invoke(parameter.Name);
+
+		class TypeNamePartition : IParameterizedSource<KeyValuePair<Assembly, Namespace>, Func<string, TypeInfo>>
+		{
+			readonly IApplicationTypes _types;
+			readonly Func<TypeInfo, bool> _specification;
+			readonly Func<TypeInfo, string> _formatter;
+
+			public TypeNamePartition(ISpecification<TypeInfo> specification, ITypeFormatter formatter)
+				: this(ApplicationTypes.Default, specification.IsSatisfiedBy, formatter.Get) {}
+
+			public TypeNamePartition(IApplicationTypes types, Func<TypeInfo, bool> specification,
+			                         Func<TypeInfo, string> formatter)
+			{
+				_types = types;
+				_specification = specification;
+				_formatter = formatter;
+			}
+
+			public Func<string, TypeInfo> Get(KeyValuePair<Assembly, Namespace> parameter)
+				=> _types.Get(parameter.Key)
+				         .Where(_specification)
+				         .ToLookup(_formatter)
+				         .ToDictionary(y => y.Key, y => y.First())
+				         .Get;
+		}
+	}
+}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/IIdentifiers.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/IIdentifiers.cs
@@ -21,13 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-namespace ExtendedXmlSerialization.ContentModel.Xml
-{
-	class XmlWriterFactory : IXmlWriterFactory
-	{
-		public static XmlWriterFactory Default { get; } = new XmlWriterFactory();
-		XmlWriterFactory() {}
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Sources;
 
-		public IXmlWriter Create(System.Xml.XmlWriter writer, object instance) => new XmlWriter(writer);
-	}
+namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
+{
+	public interface IIdentifiers : IParameterizedSource<TypeInfo, string> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/IPrefixer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/IPrefixer.cs
@@ -21,9 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using ExtendedXmlSerialization.Core.Sources;
-
 namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
-	public interface IPrefixer : IParameterizedSource<string, string> {}
+	public interface IPrefixer : IPrefixAware {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/IPrefixes.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/IPrefixes.cs
@@ -22,12 +22,9 @@
 // SOFTWARE.
 
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
-	public interface IPrefixes : IParameterizedSource<TypeInfo, string>,
-	                             IParameterizedSource<XNamespace, string>,
-	                             IParameterizedSource<string, XNamespace> {}
+	public interface IPrefixes : IPrefixAware, IParameterizedSource<TypeInfo, string> {}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Identifiers.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Identifiers.cs
@@ -21,11 +21,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using System.Reflection;
-using System.Xml.Linq;
-using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.TypeModel;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml
+namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
-	public interface INames : IParameterizedSource<TypeInfo, XName> {}
+	class Identifiers : IIdentifiers
+	{
+		public static Identifiers Default { get; } = new Identifiers();
+		Identifiers() : this(WellKnownNamespaces.Default, NamespaceFormatter.Default) {}
+
+		readonly IDictionary<Assembly, Namespace> _known;
+		readonly ITypeFormatter _formatter;
+
+		public Identifiers(IDictionary<Assembly, Namespace> known, ITypeFormatter formatter)
+		{
+			_known = known;
+			_formatter = formatter;
+		}
+
+		public string Get(TypeInfo parameter)
+			=> _known.GetStructure(parameter.Assembly)?.Identifier ?? _formatter.Get(parameter);
+	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Namespace.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Namespace.cs
@@ -1,37 +1,16 @@
-// MIT License
-// 
-// Copyright (c) 2016 Wojciech Nagórski
-//                    Michael DeMond
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-
 namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
-	public struct Namespace
+	public struct Namespace : IIdentity
 	{
-		public Namespace(string prefix, string identity)
+		public Namespace(string name) : this(name, string.Empty) {}
+
+		public Namespace(string name, string identifier)
 		{
-			Prefix = prefix;
-			Identity = identity;
+			Name = name;
+			Identifier = identifier;
 		}
 
-		public string Prefix { get; }
-		public string Identity { get; }
+		public string Name { get; }
+		public string Identifier { get; }
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Namespaces.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Namespaces.cs
@@ -21,8 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Xml.Linq;
-
 namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
 	class Namespaces : INamespaces
@@ -39,6 +37,6 @@ namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 		}
 
 		public Namespace Get(string parameter)
-			=> new Namespace(_prefixes.Get(XNamespace.Get(parameter)) ?? _prefixer.Get(parameter), parameter);
+			=> new Namespace(_prefixes.Get(parameter) ?? _prefixer.Get(parameter), parameter);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/ObjectNamespaces.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/ObjectNamespaces.cs
@@ -31,7 +31,7 @@ namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
 	class ObjectNamespaces : IObjectNamespaces
 	{
-		readonly static Func<TypeInfo, string> Identities = Namespacing.Identities.Default.Get;
+		readonly static Func<TypeInfo, string> Identities = Identifiers.Default.Get;
 
 		readonly IMembers _members;
 		readonly Func<TypeInfo, string> _names;

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/OptimizedXmlFactory.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/OptimizedXmlFactory.cs
@@ -32,10 +32,8 @@ namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 		readonly IXmlFactory _factory;
 		readonly IObjectNamespaces _namespaces;
 
-		public OptimizedXmlFactory() : this(new Containers()) {}
-
-		public OptimizedXmlFactory(IContainers containers)
-			: this(XmlFactory.Default, new ObjectNamespaces(new Members.Members(new Selector(containers)))) {}
+		public OptimizedXmlFactory(ISerializers serializers)
+			: this(XmlFactory.Default, new ObjectNamespaces(new Members.Members(serializers, new Selector(serializers)))) {}
 
 		public OptimizedXmlFactory(IXmlFactory factory, IObjectNamespaces namespaces)
 		{

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Prefixes.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/Prefixes.cs
@@ -24,26 +24,25 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 {
-	class Prefixes : DuplexTableSource<XNamespace, string>, IPrefixes
+	class Prefixes : TableSource<string, string>, IPrefixes
 	{
 		public static Prefixes Default { get; } = new Prefixes();
 
 		Prefixes() : this(WellKnownNamespaces.Default,
-		                  WellKnownNamespaces.Default.Values.ToDictionary(x => XNamespace.Get(x.Identity), x => x.Prefix)) {}
+		                  WellKnownNamespaces.Default.Values.ToDictionary(x => x.Identifier, x => x.Name)) {}
 
 		readonly IDictionary<Assembly, Namespace> _known;
 
-		public Prefixes(IDictionary<Assembly, Namespace> known, IDictionary<XNamespace, string> names) : base(names)
+		public Prefixes(IDictionary<Assembly, Namespace> known, IDictionary<string, string> names) : base(names)
 		{
 			_known = known;
 		}
 
-		public string Get(TypeInfo parameter) => _known.GetStructure(parameter.Assembly)?.Prefix;
+		public string Get(TypeInfo parameter) => _known.GetStructure(parameter.Assembly)?.Name;
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/WellKnownNamespaces.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Namespacing/WellKnownNamespaces.cs
@@ -30,16 +30,17 @@ namespace ExtendedXmlSerialization.ContentModel.Xml.Namespacing
 	{
 		public static WellKnownNamespaces Default { get; } = new WellKnownNamespaces();
 
-		WellKnownNamespaces() : base(new Dictionary<Assembly, Namespace>
-		                             {
-			                             {
-				                             typeof(IExtendedXmlSerializer).GetTypeInfo().Assembly,
-				                             new Namespace("exs", "https://github.com/wojtpl2/ExtendedXmlSerializer/v2")
-			                             },
-			                             {
-				                             typeof(object).GetTypeInfo().Assembly,
-				                             new Namespace("sys", "https://github.com/wojtpl2/ExtendedXmlSerializer/system")
-			                             }
-		                             }) {}
+		WellKnownNamespaces() : base(
+			new Dictionary<Assembly, Namespace>
+			{
+				{
+					typeof(IExtendedXmlSerializer).GetTypeInfo().Assembly,
+					new Namespace("exs", "https://github.com/wojtpl2/ExtendedXmlSerializer/v2")
+				},
+				{
+					typeof(object).GetTypeInfo().Assembly,
+					new Namespace("sys", "https://github.com/wojtpl2/ExtendedXmlSerializer/system")
+				}
+			}) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/Identities.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/Identities.cs
@@ -28,19 +28,19 @@ using Sprache;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml.Parsing
 {
-	class Identities : FixedParser<Identity>
+	class Identities : FixedParser<Key>
 	{
-		readonly static Func<string, Parser<char>> Selector = Parsing.Namespace.Accept;
+		readonly static Func<string, Parser<char>> Separator = Parse.Char(':').Accept;
 
 		public static Identities Default { get; } = new Identities();
-		Identities() : this(Parsing.Identifier) {}
+		Identities() : this(Identifier.Default) {}
 
 		public Identities(Parser<string> identifier)
 			: base(
 				identifier
-					.SelectMany(Selector, (prefix, _) => prefix)
-					.SelectMany(identifier.Accept, (prefix, name) => new Identity(name, prefix))
-					.Or(identifier.Select(x => new Identity(x)))
+					.SelectMany(Separator, (prefix, _) => prefix)
+					.SelectMany(identifier.Accept, (prefix, name) => new Key(name, prefix))
+					.Or(identifier.Select(x => new Key(x)))
 			) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/ParsedName.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/ParsedName.cs
@@ -26,17 +26,19 @@ using System.Collections.Immutable;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml.Parsing
 {
-	struct ParsedName
+	struct ParsedName : IIdentity
 	{
 		readonly Func<ImmutableArray<ParsedName>> _arguments;
 
-		public ParsedName(Identity identity, Func<ImmutableArray<ParsedName>> arguments = null)
+		public ParsedName(string name, string identifier = "", Func<ImmutableArray<ParsedName>> arguments = null)
 		{
-			Identity = identity;
+			Name = name;
+			Identifier = identifier;
 			_arguments = arguments;
 		}
 
-		public Identity Identity { get; }
+		public string Identifier { get; }
+		public string Name { get; }
 
 		public ImmutableArray<ParsedName>? GetArguments() => _arguments?.Invoke();
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/Parser.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/Parser.cs
@@ -30,16 +30,32 @@ using Sprache;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml.Parsing
 {
+	public struct Key : IIdentity
+	{
+		public Key(string name) : this(name, string.Empty) {}
+
+		public Key(string name, string identifier)
+		{
+			Name = name;
+			Identifier = identifier;
+		}
+
+		public string Identifier { get; }
+		public string Name { get; }
+	}
+
 	class Parser : FixedParser<ParsedName>
 	{
-		public static Parser Default { get; } = new Parser();
-		Parser() : this(Identities.Default, TypesList.Default.Get().Contained(Parsing.Start, Parsing.Finish).Accept) {}
+		readonly static Parser<char> Start = Parse.Char('[').Token(), Finish = Parse.Char(']').Token();
 
-		public Parser(Parser<Identity> name, Func<Identity, Parser<IEnumerable<ParsedName>>> arguments)
+		public static Parser Default { get; } = new Parser();
+		Parser() : this(Identities.Default, TypesList.Default.Get().Contained(Start, Finish).Accept) {}
+
+		public Parser(Parser<Key> keys, Func<Key, Parser<IEnumerable<ParsedName>>> arguments)
 			: base(
-				name.SelectMany(arguments,
-				                (item, argument) => new ParsedName(item, argument.ToImmutableArray))
-				    .Or(name.Select(x => new ParsedName(x)))
+				keys.SelectMany(arguments,
+				                (key, argument) => new ParsedName(key.Name, key.Identifier, argument.ToImmutableArray))
+				    .Or(keys.Select(key => new ParsedName(key.Name, key.Identifier)))
 			) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/TypesList.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Parsing/TypesList.cs
@@ -21,7 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using ExtendedXmlSerialization.Core.Sources;
 using Sprache;
@@ -30,13 +29,9 @@ namespace ExtendedXmlSerialization.ContentModel.Xml.Parsing
 {
 	class TypesList : FixedParser<IEnumerable<ParsedName>>
 	{
-		public static TypesList Default { get; } = new TypesList();
-		TypesList() : this(() => Parser.Default.Get()) {}
+		readonly static Parser<char> List = Parse.Char(',').Token();
 
-		public TypesList(Func<Parser<ParsedName>> reference)
-			: base(Parse.Ref(reference)
-			            .DelimitedBy(Parsing.List)
-			            .Token()
-			) {}
+		public static TypesList Default { get; } = new TypesList();
+		TypesList() : base(Parse.Ref(() => Parser.Default.Get()).DelimitedBy(List).Token()) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypeAliases.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypeAliases.cs
@@ -41,7 +41,7 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			_names = names;
 		}
 
-		protected override string Create(TypeInfo parameter)
+		public override string Get(TypeInfo parameter)
 			=> _names.Get(parameter.AsType()) ?? parameter.GetCustomAttribute<XmlRootAttribute>()?.ElementName;
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypeFormatter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypeFormatter.cs
@@ -22,12 +22,11 @@
 // SOFTWARE.
 
 using System.Reflection;
-using ExtendedXmlSerialization.Core.Sources;
 using ExtendedXmlSerialization.TypeModel;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class TypeFormatter : ReferenceCacheBase<TypeInfo, string>, ITypeFormatter
+	class TypeFormatter : ITypeFormatter
 	{
 		public static TypeFormatter Default { get; } = new TypeFormatter();
 		TypeFormatter() : this(TypeAliases.Default, ContentModel.TypeFormatter.Default) {}
@@ -41,6 +40,6 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			_formatter = formatter;
 		}
 
-		protected override string Create(TypeInfo parameter) => _alias.Get(parameter) ?? _formatter.Get(parameter);
+		public string Get(TypeInfo parameter) => _alias.Get(parameter) ?? _formatter.Get(parameter);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypeLoader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypeLoader.cs
@@ -21,32 +21,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
-using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core;
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.TypeModel;
 
-namespace ExtendedXmlSerialization.ContentModel.Members
+namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class MemberedReader : DecoratedReader
+	class TypeLoader : ITypePartitions
 	{
-		readonly IDictionary<string, IMember> _members;
+		public static TypeLoader Default { get; } = new TypeLoader();
+		TypeLoader() : this(TypeNameAlteration.Default) {}
 
-		public MemberedReader(IReader reader, IDictionary<string, IMember> members) : base(reader)
+		readonly IAlteration<string> _names;
+
+		public TypeLoader(IAlteration<string> names)
 		{
-			_members = members;
+			_names = names;
 		}
 
-		public override object Get(IXmlReader parameter)
-		{
-			var result = base.Get(parameter);
-			var members = parameter.Members();
-			while (members.MoveNext())
-			{
-				var member = _members.Get(members.Current);
-				member?.Assign(result, ((IReader) member).Get(parameter));
-			}
-
-			return result;
-		}
+		public TypeInfo Get(TypePartition parameter)
+			=> parameter.Assembly.GetType($"{parameter.Namespace}.{_names.Get(parameter.Name)}", false, false)?.GetTypeInfo();
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypeOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypeOption.cs
@@ -43,6 +43,6 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			_types = types;
 		}
 
-		public override TypeInfo Get(IXmlReader parameter) => _types.Get(parameter.Name);
+		public override TypeInfo Get(IXmlReader parameter) => _types.Get(parameter.Identity);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypePartitions.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypePartitions.cs
@@ -21,37 +21,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
-using System.Linq;
 using System.Reflection;
-using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.Core.Sources;
 using ExtendedXmlSerialization.TypeModel;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class TypePartitions : ITypePartitions
+	class TypePartitions : FirstAssignedSource<TypePartition, TypeInfo>, ITypePartitions
 	{
-		readonly static Func<TypeInfo, string> Formatter = TypeFormatter.Default.Get;
-		readonly static Func<TypeInfo, bool> Specification = CanPartitionSpecification.Default.IsSatisfiedBy;
-
-		readonly Func<TypeInfo, bool> _specification;
-		readonly Func<TypeInfo, string> _key;
-
-		public static TypePartitions Default { get; } = new TypePartitions();
-		TypePartitions() : this(x => x.Namespace) {}
-
-		public TypePartitions(Func<TypeInfo, string> key) : this(Specification, key) {}
-
-		public TypePartitions(Func<TypeInfo, bool> specification, Func<TypeInfo, string> key)
-		{
-			_specification = specification;
-			_key = key;
-		}
-
-		public Partition Get(Assembly parameter) =>
-			parameter.ExportedTypes.YieldMetadata(_specification)
-			         .ToLookup(_key)
-			         .ToDictionary(x => x.Key, x => new Func<string, TypeInfo>(x.ToDictionary(Formatter).Get))
-			         .Get;
+		public TypePartitions(params IParameterizedSource<TypePartition, TypeInfo>[] sources) : base(sources) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypePropertyOptionBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypePropertyOptionBase.cs
@@ -27,7 +27,7 @@ using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	abstract class TypePropertyOptionBase : Option<IXmlReader, TypeInfo>, ITypeOption
+	abstract class TypePropertyOptionBase : DelegatedOption<IXmlReader, TypeInfo>, ITypeOption
 	{
 		protected TypePropertyOptionBase(ITypeProperty property) : base(new ContainsSpecification(property), property.Get) {}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypePropertyOptionBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypePropertyOptionBase.cs
@@ -29,7 +29,6 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 {
 	abstract class TypePropertyOptionBase : Option<IXmlReader, TypeInfo>, ITypeOption
 	{
-		protected TypePropertyOptionBase(ITypeProperty property)
-			: base(new ContainsNameSpecification(property.Name), property.Get) {}
+		protected TypePropertyOptionBase(ITypeProperty property) : base(new ContainsSpecification(property), property.Get) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/TypeSelector.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/TypeSelector.cs
@@ -45,6 +45,7 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			{
 				throw new InvalidOperationException($"Could not locate the type for the Xml reader '{parameter}.'");
 			}
+
 			return result;
 		}
 	}

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Types.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Types.cs
@@ -24,33 +24,35 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class Types : ReferenceCacheBase<XName, TypeInfo>, ITypes
+	class Types : ReferenceCacheBase<IIdentity, TypeInfo>, ITypes
 	{
 		public static Types Default { get; } = new Types();
 
 		Types()
 			: this(
-				WellKnownAliases.Default.Select(x => x.Key).YieldMetadata().ToDictionary(Names.Default.Get),
+				WellKnownAliases.Default
+								.Select(x => x.Key)
+				                .YieldMetadata()
+				                .ToDictionary(Identities.Default.Get),
 				WellKnownTypeLocator.Default,
 				AssemblyPartitionedTypes.Default) {}
 
-		readonly IDictionary<XName, TypeInfo> _aliased;
+		readonly IDictionary<IIdentity, TypeInfo> _aliased;
 		readonly ITypes _known, _partitions;
 
-		public Types(IDictionary<XName, TypeInfo> aliased, ITypes known, ITypes partitions)
+		public Types(IDictionary<IIdentity, TypeInfo> aliased, ITypes known, ITypes partitions)
 		{
 			_aliased = aliased;
 			_known = known;
 			_partitions = partitions;
 		}
 
-		protected override TypeInfo Create(XName parameter)
+		protected override TypeInfo Create(IIdentity parameter)
 			=> _aliased.Get(parameter) ?? _known.Get(parameter) ?? _partitions.Get(parameter);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Types.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Types.cs
@@ -26,24 +26,27 @@ using System.Linq;
 using System.Reflection;
 using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.Core.Specifications;
+using ExtendedXmlSerialization.TypeModel;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
 	class Types : ReferenceCacheBase<IIdentity, TypeInfo>, ITypes
 	{
-		public static Types Default { get; } = new Types();
+		readonly static Dictionary<IIdentity, TypeInfo> Aliased = WellKnownAliases.Default
+		                                                                          .Select(x => x.Key)
+		                                                                          .YieldMetadata()
+		                                                                          .ToDictionary(Identities.Default.Get);
 
-		Types()
-			: this(
-				WellKnownAliases.Default
-								.Select(x => x.Key)
-				                .YieldMetadata()
-				                .ToDictionary(Identities.Default.Get),
-				WellKnownTypeLocator.Default,
-				AssemblyPartitionedTypes.Default) {}
+		public static Types Default { get; } = new Types();
+		Types() : this(HasAliasSpecification.Default, TypeLoader.Default, AssemblyTypePartitions.Default) {}
 
 		readonly IDictionary<IIdentity, TypeInfo> _aliased;
+
 		readonly ITypes _known, _partitions;
+
+		public Types(ISpecification<TypeInfo> specification, params ITypePartitions[] partitions)
+			: this(Aliased, new IdentityPartitionedTypes(specification), new PartitionedTypes(partitions)) {}
 
 		public Types(IDictionary<IIdentity, TypeInfo> aliased, ITypes known, ITypes partitions)
 		{

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/WellKnownTypeLocator.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/WellKnownTypeLocator.cs
@@ -24,7 +24,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Xml.Linq;
 using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
 using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.TypeModel;
@@ -37,7 +36,7 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 
 		WellKnownTypeLocator()
 			: this(WellKnownNamespaces.Default.ToDictionary(
-				       x => x.Value.Identity,
+				       x => x.Value.Identifier,
 				       x => new Func<string, TypeInfo>(
 					       x.Key.ExportedTypes
 					        .YieldMetadata(CanPartitionSpecification.Default.IsSatisfiedBy)
@@ -53,6 +52,6 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			_types = types;
 		}
 
-		public TypeInfo Get(XName parameter) => _types.Invoke(parameter.NamespaceName)?.Invoke(parameter.LocalName);
+		public TypeInfo Get(IIdentity parameter) => _types.Invoke(parameter.Identifier)?.Invoke(parameter.Name);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/XmlFactory.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/XmlFactory.cs
@@ -21,10 +21,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.IO;
+using System.Xml;
+
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	public interface IXmlWriterFactory
+	class XmlFactory : IXmlFactory
 	{
-		IXmlWriter Create(System.Xml.XmlWriter writer, object instance);
+		readonly static XmlReaderSettings XmlReaderSettings = new XmlReaderSettings
+		                                                      {
+			                                                      IgnoreWhitespace = true,
+			                                                      IgnoreComments = true,
+			                                                      IgnoreProcessingInstructions = true
+		                                                      };
+
+		public static XmlFactory Default { get; } = new XmlFactory();
+		XmlFactory() {}
+
+		public IXmlWriter Create(Stream stream, object instance) => new XmlWriter(System.Xml.XmlWriter.Create(stream));
+
+		public IXmlReader Create(Stream stream)
+		{
+			var reader = System.Xml.XmlReader.Create(stream, XmlReaderSettings);
+			var result = new XmlReader(reader);
+			return result;
+		}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/XmlReader.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/XmlReader.cs
@@ -22,18 +22,12 @@
 // SOFTWARE.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Xml;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
 	class XmlReader : IXmlReader
 	{
-		readonly static TypeSelector TypeSelector = TypeSelector.Default;
-		readonly static ContentModel.Identities Identities = ContentModel.Identities.Default;
-
 		readonly System.Xml.XmlReader _reader;
 
 		public XmlReader(System.Xml.XmlReader reader)
@@ -46,11 +40,11 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 				default:
 					throw new InvalidOperationException($"Could not locate the content from the Xml reader '{reader}.'");
 			}
-			
 		}
 
-		public IIdentity Identity => Identities.Get(_reader.LocalName, _reader.NamespaceURI);
-		public TypeInfo Classification => TypeSelector.Get(this);
+		public string Name => _reader.LocalName;
+		public string Identifier => _reader.NamespaceURI;
+		public string Prefix => _reader.Prefix;
 
 		public string Value()
 		{
@@ -69,41 +63,18 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			}
 		}
 
-		public IEnumerator<string> Members() => Items(); // Same for now...
-		public IEnumerator<string> Items() => new Enumerator(_reader, _reader.Depth + 1);
+		public int Depth => _reader.Depth;
+		public bool Advance() => _reader.Read() && _reader.IsStartElement();
 
 		public bool Contains(IIdentity identity)
 			=> _reader.HasAttributes && _reader.MoveToAttribute(identity.Name, identity.Identifier);
 
 		public string Get(string parameter) => _reader.LookupNamespace(parameter);
 
+
 		public override string ToString()
 			=> $"{base.ToString()}: {XmlQualifiedName.ToString(_reader.LocalName, _reader.NamespaceURI)}";
 
 		public void Dispose() => _reader.Dispose();
-
-		sealed class Enumerator : IEnumerator<string>
-		{
-			readonly System.Xml.XmlReader _reader;
-			readonly int _depth;
-
-			public Enumerator(System.Xml.XmlReader reader, int depth)
-			{
-				_reader = reader;
-				_depth = depth;
-			}
-
-			public string Current => _reader.LocalName;
-			object IEnumerator.Current => _reader;
-
-			public bool MoveNext() => _reader.Read() && _reader.IsStartElement() && _reader.Depth == _depth;
-
-			public void Reset()
-			{
-				throw new NotSupportedException();
-			}
-
-			public void Dispose() => Reset();
-		}
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/XmlWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/XmlWriter.cs
@@ -42,10 +42,20 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 			_writer = writer;
 		}
 
-		public void Attribute(XName name, string value) =>
-			_writer.WriteAttributeString(Get(name.Namespace), name.LocalName, name.NamespaceName, value);
+		public void Attribute(Attribute attribute)
+		{
+			if (attribute.Namespace.HasValue)
+			{
+				_writer.WriteAttributeString(attribute.Namespace?.Name, attribute.Name, attribute.Namespace?.Identifier, attribute.Identifier);
+			}
+			else
+			{
+				_writer.WriteAttributeString(attribute.Name, attribute.Identifier);
+			}
+			// _writer.WriteAttributeString();
+		}
 
-		public void Element(XName name) => _writer.WriteStartElement(name.LocalName, name.NamespaceName);
+		public void Element(IIdentity name) => _writer.WriteStartElement(name.Name, name.Identifier);
 
 		public void Member(string name) => _writer.WriteStartElement(name);
 
@@ -55,13 +65,12 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 
 		public void Dispose() => _writer.Dispose();
 
-		public string Get(XNamespace parameter)
-			=> _writer.LookupPrefix(parameter.NamespaceName) ?? Create(parameter.NamespaceName);
+		public string Get(string identifier) => _writer.LookupPrefix(identifier) ?? Create(identifier);
 
-		string Create(XNamespace @namespace)
+		string Create(string identifier)
 		{
-			_writer.WriteAttributeString(_prefixes.Get(@namespace), Xmlns, @namespace.NamespaceName);
-			return _writer.LookupPrefix(@namespace.NamespaceName);
+			_writer.WriteAttributeString(_prefixes.Get(identifier), Xmlns, identifier);
+			return _writer.LookupPrefix(identifier);
 		}
 	}
 }

--- a/src/ExtendedXmlSerializer/Core/Extensions.cs
+++ b/src/ExtendedXmlSerializer/Core/Extensions.cs
@@ -24,6 +24,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
 using ExtendedXmlSerialization.Core.Sources;
@@ -33,6 +34,14 @@ namespace ExtendedXmlSerialization.Core
 {
 	public static class Extensions
 	{
+		public static IReadOnlyList<T> AsReadOnly<T>(this IEnumerable<T> @this) => new ReadOnlyCollection<T>(@this.ToArray());
+
+		public static ISpecification<T> Or<T>(this ISpecification<T> @this, params ISpecification<T>[] others)
+			=> new AnySpecification<T>(@this.Yield().Concat(others).Fixed());
+
+		public static ISpecification<T> And<T>(this ISpecification<T> @this, params ISpecification<T>[] others)
+			=> new AllSpecification<T>(@this.Yield().Concat(others).Fixed());
+
 		public static T[] Fixed<T>(this IEnumerable<T> @this) => @this as T[] ?? @this.ToArray();
 
 		public static Func<TParameter, TResult> Alter<TParameter, TResult>(this IAlteration<TResult> @this,

--- a/src/ExtendedXmlSerializer/Core/IAllInterfaces.cs
+++ b/src/ExtendedXmlSerializer/Core/IAllInterfaces.cs
@@ -1,0 +1,31 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Sources;
+
+namespace ExtendedXmlSerialization.Core
+{
+	public interface IAllInterfaces : IParameterizedSource<TypeInfo, IReadOnlyList<TypeInfo>> {}
+}

--- a/src/ExtendedXmlSerializer/Core/Sources/CacheBase.cs
+++ b/src/ExtendedXmlSerializer/Core/Sources/CacheBase.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace ExtendedXmlSerialization.Core.Sources
 {
@@ -30,7 +31,9 @@ namespace ExtendedXmlSerialization.Core.Sources
 	{
 		readonly Func<TKey, TValue> _create;
 
-		protected CacheBase()
+		protected CacheBase() : this(EqualityComparer<TKey>.Default) {}
+
+		protected CacheBase(IEqualityComparer<TKey> comparer) : base(comparer)
 		{
 			_create = Create;
 		}

--- a/src/ExtendedXmlSerializer/Core/Sources/FirstAssignedSource.cs
+++ b/src/ExtendedXmlSerializer/Core/Sources/FirstAssignedSource.cs
@@ -21,21 +21,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
-using ExtendedXmlSerialization.Core.Specifications;
+using System.Collections.Immutable;
 
 namespace ExtendedXmlSerialization.Core.Sources
 {
-	public class Option<TParameter, TResult> : OptionBase<TParameter, TResult>
+	public class FirstAssignedSource<TParameter, TResult> : IParameterizedSource<TParameter, TResult>
 	{
-		readonly Func<TParameter, TResult> _source;
+		readonly ImmutableArray<IParameterizedSource<TParameter, TResult>> _sources;
 
-		public Option(ISpecification<TParameter> specification, Func<TParameter, TResult> source)
-			: base(specification)
+		public FirstAssignedSource(params IParameterizedSource<TParameter, TResult>[] sources)
 		{
-			_source = source;
+			_sources = sources.ToImmutableArray();
 		}
 
-		public override TResult Get(TParameter parameter) => _source(parameter);
+		public TResult Get(TParameter parameter)
+		{
+			var length = _sources.Length;
+			for (var i = 0; i < length; i++)
+			{
+				var result = _sources[i].Get(parameter);
+				if (!Equals(result, default(TResult)))
+				{
+					return result;
+				}
+			}
+			return default(TResult);
+		}
 	}
 }

--- a/src/ExtendedXmlSerializer/Core/Sources/FixedOption.cs
+++ b/src/ExtendedXmlSerializer/Core/Sources/FixedOption.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.Core.Sources
@@ -28,6 +29,11 @@ namespace ExtendedXmlSerialization.Core.Sources
 	public class FixedOption<TParameter, TResult> : OptionBase<TParameter, TResult>
 	{
 		readonly TResult _instance;
+
+		public FixedOption(TResult instance) : this(x => true, instance) {}
+
+		public FixedOption(Func<TParameter, bool> specification, TResult instance)
+			: this(new DelegatedSpecification<TParameter>(specification), instance) {}
 
 		public FixedOption(ISpecification<TParameter> specification, TResult instance) : base(specification)
 		{

--- a/src/ExtendedXmlSerializer/Core/Sources/InternedCacheBase.cs
+++ b/src/ExtendedXmlSerializer/Core/Sources/InternedCacheBase.cs
@@ -1,0 +1,18 @@
+using System.Runtime.CompilerServices;
+
+namespace ExtendedXmlSerialization.Core.Sources
+{
+	public abstract class InternedCacheBase<T> : ReferenceCache<string, T> where T : class
+	{
+		readonly IAlteration<string> _intern;
+
+		protected InternedCacheBase(ConditionalWeakTable<string, T>.CreateValueCallback create) : this(Interns.Default, create) {}
+
+		protected InternedCacheBase(IAlteration<string> intern, ConditionalWeakTable<string, T>.CreateValueCallback create) : base(create)
+		{
+			_intern = intern;
+		}
+
+		public override T Get(string key) => base.Get(_intern.Get(key));
+	}
+}

--- a/src/ExtendedXmlSerializer/Core/Sources/Interns.cs
+++ b/src/ExtendedXmlSerializer/Core/Sources/Interns.cs
@@ -21,12 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Xml.Linq;
-
-namespace ExtendedXmlSerialization.ContentModel.Xml
+namespace ExtendedXmlSerialization.Core.Sources
 {
-	public interface IEntity
+	public class Interns : Cache<string, string>, IAlteration<string>
 	{
-		XName Name { get; }
+		// TODO: replace when .NET standard 2.0 is available.
+		// https://github.com/IronLanguages/main/issues/1381
+		public static Interns Default { get; } = new Interns();
+		Interns() : base(x => x) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/Core/Sources/ReferenceCacheBase.cs
+++ b/src/ExtendedXmlSerializer/Core/Sources/ReferenceCacheBase.cs
@@ -38,6 +38,6 @@ namespace ExtendedXmlSerialization.Core.Sources
 
 		protected abstract TValue Create(TKey parameter);
 
-		public TValue Get(TKey key) => _cache.GetValue(key, _callback);
+		public virtual TValue Get(TKey key) => _cache.GetValue(key, _callback);
 	}
 }

--- a/src/ExtendedXmlSerializer/Core/Specifications/AssignedSpecification.cs
+++ b/src/ExtendedXmlSerializer/Core/Specifications/AssignedSpecification.cs
@@ -1,0 +1,33 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace ExtendedXmlSerialization.Core.Specifications
+{
+	public class AssignedSpecification : ISpecification<object>
+	{
+		public static AssignedSpecification Default { get; } = new AssignedSpecification();
+		AssignedSpecification() {}
+
+		public bool IsSatisfiedBy(object parameter) => parameter != null;
+	}
+}

--- a/src/ExtendedXmlSerializer/Core/Specifications/ContainsItemsSpecification.cs
+++ b/src/ExtendedXmlSerializer/Core/Specifications/ContainsItemsSpecification.cs
@@ -1,0 +1,35 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
+
+namespace ExtendedXmlSerialization.Core.Specifications
+{
+	public class ContainsItemsSpecification : SpecificationAdapterBase<ICollection>
+	{
+		public static ContainsItemsSpecification Default { get; } = new ContainsItemsSpecification();
+		ContainsItemsSpecification() {}
+
+		protected override bool IsSatisfiedBy(ICollection parameter) => parameter.Count > 0;
+	}
+}

--- a/src/ExtendedXmlSerializer/Core/Specifications/GenericDefinitionCandidates.cs
+++ b/src/ExtendedXmlSerializer/Core/Specifications/GenericDefinitionCandidates.cs
@@ -1,0 +1,44 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.Core.Specifications
+{
+	class GenericDefinitionCandidates : IGenericDefinitionCandidates
+	{
+		public static GenericDefinitionCandidates Default { get; } = new GenericDefinitionCandidates();
+		GenericDefinitionCandidates() {}
+
+		// ATTRIBUTION: http://stackoverflow.com/a/5461399/3602057
+		public ImmutableArray<Type> Get(TypeInfo parameter) => parameter.AsType()
+		                                                                .Yield()
+		                                                                .Appending(parameter.GetInterfaces())
+		                                                                .YieldMetadata(x => x.IsGenericType)
+		                                                                .Select(x => x.GetGenericTypeDefinition())
+		                                                                .ToImmutableArray();
+	}
+}

--- a/src/ExtendedXmlSerializer/Core/Specifications/IGenericDefinitionCandidates.cs
+++ b/src/ExtendedXmlSerializer/Core/Specifications/IGenericDefinitionCandidates.cs
@@ -1,0 +1,32 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Immutable;
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Sources;
+
+namespace ExtendedXmlSerialization.Core.Specifications
+{
+	public interface IGenericDefinitionCandidates : IParameterizedSource<TypeInfo, ImmutableArray<Type>> {}
+}

--- a/src/ExtendedXmlSerializer/Core/Specifications/IsAssignableGenericSpecification.cs
+++ b/src/ExtendedXmlSerializer/Core/Specifications/IsAssignableGenericSpecification.cs
@@ -28,24 +28,22 @@ namespace ExtendedXmlSerialization.Core.Specifications
 {
 	public class IsAssignableGenericSpecification : ISpecification<TypeInfo>
 	{
-		readonly Type _genericType;
+		readonly IGenericDefinitionCandidates _candidates;
+		readonly Type _genericDefinition;
 
-		public IsAssignableGenericSpecification(Type genericType)
+		public IsAssignableGenericSpecification(Type genericType) : this(GenericDefinitionCandidates.Default, genericType) {}
+
+		public IsAssignableGenericSpecification(IGenericDefinitionCandidates candidates, Type genericDefinition)
 		{
-			_genericType = genericType;
+			_candidates = candidates;
+			_genericDefinition = genericDefinition;
 		}
 
-		// ATTRIBUTION: http://stackoverflow.com/a/5461399/3602057
 		public bool IsSatisfiedBy(TypeInfo parameter)
+			=> _candidates.Get(parameter).Contains(_genericDefinition) || Base(parameter);
+
+		bool Base(TypeInfo parameter)
 		{
-			var interfaceTypes = parameter.GetInterfaces();
-
-			foreach (var it in interfaceTypes.Appending(parameter.AsType()))
-			{
-				if (it.GetTypeInfo().IsGenericType && it.GetGenericTypeDefinition() == _genericType)
-					return true;
-			}
-
 			var baseType = parameter.BaseType?.GetTypeInfo();
 			var result = baseType != null && IsSatisfiedBy(baseType);
 			return result;

--- a/src/ExtendedXmlSerializer/ExtendedXmlSerializer.cs
+++ b/src/ExtendedXmlSerializer/ExtendedXmlSerializer.cs
@@ -33,29 +33,22 @@ namespace ExtendedXmlSerialization
 	/// </summary>
 	public class ExtendedXmlSerializer : IExtendedXmlSerializer
 	{
-		readonly static TypeSelector Selector = TypeSelector.Default;
-		readonly static XmlFactory Factory = XmlFactory.Default;
-
 		readonly ITypeSelector _selector;
 		readonly IXmlFactory _factory;
-		readonly IContainers _containers;
+		readonly ISerializers _serializers;
 
-		public ExtendedXmlSerializer() : this(Factory) {}
-
-		public ExtendedXmlSerializer(IXmlFactory factory) : this(Selector, factory, new Containers()) {}
-
-		public ExtendedXmlSerializer(ITypeSelector selector, IXmlFactory factory, IContainers containers)
+		public ExtendedXmlSerializer(ITypeSelector selector, IXmlFactory factory, ISerializers serializers)
 		{
 			_selector = selector;
 			_factory = factory;
-			_containers = containers;
+			_serializers = serializers;
 		}
 
 		public void Serialize(Stream stream, object instance)
 		{
 			using (var writer = _factory.Create(stream, instance))
 			{
-				_containers.Get(instance.GetType().GetTypeInfo()).Write(writer, instance);
+				_serializers.Get(instance.GetType().GetTypeInfo()).Write(writer, instance);
 			}
 		}
 
@@ -63,7 +56,7 @@ namespace ExtendedXmlSerialization
 		{
 			using (var reader = _factory.Create(stream))
 			{
-				return _containers.Get(_selector.Get(reader)).Get(reader);
+				return _serializers.Get(_selector.Get(reader)).Get(reader);
 			}
 		}
 	}

--- a/src/ExtendedXmlSerializer/TypeModel/AddMethodLocator.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/AddMethodLocator.cs
@@ -37,7 +37,7 @@ namespace ExtendedXmlSerialization.TypeModel
 
 		static MethodInfo Get(TypeInfo type, TypeInfo elementType)
 		{
-			foreach (var candidate in AllInterfaces.Instance.Yield(type))
+			foreach (var candidate in AllInterfaces.Default.Get(type))
 			{
 				var method = candidate.GetMethod(Add);
 				var parameters = method?.GetParameters();

--- a/src/ExtendedXmlSerializer/TypeModel/ApplicationTypes.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/ApplicationTypes.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.TypeModel
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	class ApplicationTypes : ReferenceCacheBase<Assembly, IReadOnlyList<TypeInfo>>, IApplicationTypes
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
+		readonly static Type AttributeType = typeof(CompilerGeneratedAttribute);
 
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
+		public static ApplicationTypes Default { get; } = new ApplicationTypes();
+		ApplicationTypes() {}
 
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
-		{
-			_interfaces = interfaces;
-			_identity = identity;
-		}
-
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		protected override IReadOnlyList<TypeInfo> Create(Assembly parameter)
+			=> parameter.DefinedTypes.Where(x => !x.IsDefined(AttributeType)).AsReadOnly();
 	}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/CompositeTypeComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/CompositeTypeComparer.cs
@@ -50,6 +50,6 @@ namespace ExtendedXmlSerialization.TypeModel
 			return false;
 		}
 
-		public int GetHashCode(TypeInfo obj) => obj.GetHashCode();
+		public int GetHashCode(TypeInfo obj) => 0;
 	}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/CompositeTypeComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/CompositeTypeComparer.cs
@@ -1,0 +1,55 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public class CompositeTypeComparer : ITypeComparer
+	{
+		readonly ImmutableArray<ITypeComparer> _comparers;
+
+		public CompositeTypeComparer(params ITypeComparer[] comparers) : this(comparers.ToImmutableArray()) {}
+
+		public CompositeTypeComparer(ImmutableArray<ITypeComparer> comparers)
+		{
+			_comparers = comparers;
+		}
+
+		public bool Equals(TypeInfo x, TypeInfo y)
+		{
+			var length = _comparers.Length;
+			for (var i = 0; i < length; i++)
+			{
+				if (_comparers[i].Equals(x, y))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public int GetHashCode(TypeInfo obj) => obj.GetHashCode();
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/Defaults.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/Defaults.cs
@@ -1,0 +1,31 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public static class Defaults
+	{
+		public static ITypeComparer TypeComparer { get; } = new CompositeTypeComparer(ImplementedTypeComparer.Default,
+		                                                                              TypeIdentityComparer.Default);
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/IApplicationTypes.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/IApplicationTypes.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
+using System.Collections.Generic;
 using System.Reflection;
+using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.TypeModel
 {
-	public class ImplementedTypeComparer : ITypeComparer
-	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
-
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
-		{
-			_interfaces = interfaces;
-			_identity = identity;
-		}
-
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
-	}
+	public interface IApplicationTypes : IParameterizedSource<Assembly, IReadOnlyList<TypeInfo>> {}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/IInterfaceIdentities.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/IInterfaceIdentities.cs
@@ -1,0 +1,32 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Sources;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public interface IInterfaceIdentities : IParameterizedSource<TypeInfo, IReadOnlyList<Guid>> {}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/IMemberComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/IMemberComparer.cs
@@ -1,0 +1,30 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public interface IMemberComparer : IEqualityComparer<MemberInfo> {}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/ITypeComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/ITypeComparer.cs
@@ -1,0 +1,30 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public interface ITypeComparer : IEqualityComparer<TypeInfo> {}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/ITypePartitions.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/ITypePartitions.cs
@@ -26,5 +26,5 @@ using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.TypeModel
 {
-	public interface ITypePartitions : IParameterizedSource<Assembly, Partition> {}
+	public interface ITypePartitions : IParameterizedSource<TypePartition, TypeInfo> {}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/ImplementedTypeComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/ImplementedTypeComparer.cs
@@ -1,6 +1,6 @@
-// MIT License
+﻿// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nag�rski
+// Copyright (c) 2016 Wojciech Nagórski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,14 +21,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections;
+using System.Linq;
+using System.Reflection;
 
-namespace ExtendedXmlSerialization.ContentModel.Collections
+namespace ExtendedXmlSerialization.TypeModel
 {
-	class DictionaryWriter : EnumerableWriter<IDictionary>
+	public class ImplementedTypeComparer : ITypeComparer
 	{
-		public DictionaryWriter(IWriter item) : base(item) {}
+		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
+		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
 
-		protected override IEnumerator Get(IDictionary instance) => instance.GetEnumerator();
+		readonly IInterfaceIdentities _interfaces;
+		readonly ITypeComparer _identity;
+
+		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
+		{
+			_interfaces = interfaces;
+			_identity = identity;
+		}
+
+		public bool Equals(TypeInfo x, TypeInfo y)
+		{
+			var left = x.IsInterface;
+			if (left != y.IsInterface)
+			{
+				var @interface = left ? x : y;
+				var implementation = left ? y : x;
+				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
+				return contains;
+			}
+			var result = _identity.Equals(x, y);
+			return result;
+		}
+
+		public int GetHashCode(TypeInfo obj) => _identity.GetHashCode(obj);
 	}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/InterfaceIdentities.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/InterfaceIdentities.cs
@@ -1,0 +1,46 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ExtendedXmlSerialization.Core;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	class InterfaceIdentities : IInterfaceIdentities
+	{
+		public static InterfaceIdentities Default { get; } = new InterfaceIdentities();
+		InterfaceIdentities() : this(AllInterfaces.Default) {}
+
+		readonly IAllInterfaces _interfaces;
+
+		public InterfaceIdentities(IAllInterfaces interfaces)
+		{
+			_interfaces = interfaces;
+		}
+
+		public IReadOnlyList<Guid> Get(TypeInfo parameter) => _interfaces.Get(parameter).Select(x => x.GUID).AsReadOnly();
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/MemberComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/MemberComparer.cs
@@ -1,0 +1,45 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public class MemberComparer : IMemberComparer
+	{
+		public static MemberComparer Default { get; } = new MemberComparer();
+		MemberComparer() : this(Defaults.TypeComparer) {}
+
+		readonly ITypeComparer _type;
+
+		public MemberComparer(ITypeComparer type)
+		{
+			_type = type;
+		}
+
+		public bool Equals(MemberInfo x, MemberInfo y)
+			=> x.Name.Equals(y.Name) && _type.Equals(x.DeclaringType.GetTypeInfo(), y.DeclaringType.GetTypeInfo());
+
+		public int GetHashCode(MemberInfo obj) => 0;
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/TypeDefinitionIdentityComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/TypeDefinitionIdentityComparer.cs
@@ -1,0 +1,35 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public class TypeDefinitionIdentityComparer : TypeIdentityComparerBase
+	{
+		public static TypeDefinitionIdentityComparer Default { get; } = new TypeDefinitionIdentityComparer();
+		TypeDefinitionIdentityComparer() {}
+
+		public override int GetHashCode(TypeInfo obj) => obj.GUID.GetHashCode();
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/TypeIdentityComparer.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/TypeIdentityComparer.cs
@@ -1,0 +1,35 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public class TypeIdentityComparer : TypeIdentityComparerBase
+	{
+		public static TypeIdentityComparer Default { get; } = new TypeIdentityComparer();
+		TypeIdentityComparer() {}
+
+		public override int GetHashCode(TypeInfo obj) => obj.GetHashCode();
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/TypeIdentityComparerBase.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/TypeIdentityComparerBase.cs
@@ -1,0 +1,33 @@
+// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
+
+namespace ExtendedXmlSerialization.TypeModel
+{
+	public abstract class TypeIdentityComparerBase : ITypeComparer
+	{
+		public virtual bool Equals(TypeInfo x, TypeInfo y) => GetHashCode(x).Equals(GetHashCode(y));
+		public abstract int GetHashCode(TypeInfo obj);
+	}
+}

--- a/src/ExtendedXmlSerializer/TypeModel/TypePartition.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/TypePartition.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
 using System.Reflection;
 
 namespace ExtendedXmlSerialization.TypeModel
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	public struct TypePartition
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
-
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
+		public TypePartition(Assembly assembly, string @namespace, string name)
 		{
-			_interfaces = interfaces;
-			_identity = identity;
+			Assembly = assembly;
+			Namespace = @namespace;
+			Name = name;
 		}
 
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		public Assembly Assembly { get; }
+		public string Namespace { get; }
+		public string Name { get; }
 	}
 }

--- a/test/ExtendedXmlSerializer.Performance.Tests/Benchmarks.cs
+++ b/test/ExtendedXmlSerializer.Performance.Tests/Benchmarks.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Text;
 using System.Xml.Serialization;
 using BenchmarkDotNet.Attributes;
+using ExtendedXmlSerialization.Configuration;
 using ExtendedXmlSerialization.Performance.Tests.Model;
 
 namespace ExtendedXmlSerialization.Performance.Tests
@@ -53,7 +54,7 @@ namespace ExtendedXmlSerialization.Performance.Tests
 
 	public class ExtendedXmlSerializerV2Test
 	{
-		readonly IExtendedXmlSerializer _serializer = new ExtendedXmlSerializer();
+		readonly IExtendedXmlSerializer _serializer = new ExtendedXmlConfiguration().Create();
 		readonly TestClassOtherClass _obj = new TestClassOtherClass().Init();
 		readonly byte[] _xml;
 

--- a/test/ExtendedXmlSerializerTest/ContentModel/Members/BlacklistMemberPolicyTests.cs
+++ b/test/ExtendedXmlSerializerTest/ContentModel/Members/BlacklistMemberPolicyTests.cs
@@ -49,5 +49,19 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 				Assert.True(sut.IsSatisfiedBy(property));
 			}
 		}
+
+		[Fact]
+		public void Inherited()
+		{
+			const string name = nameof(IDictionary<object, object>.Keys);
+			var ignore = typeof(IDictionary<,>).GetRuntimeProperty(name);
+			var sut = new BlacklistMemberPolicy(ignore);
+			var instance = new Dictionary();
+			var type = instance.GetType();
+			var candidate = type.GetRuntimeProperty(name);
+			var allowed = sut.IsSatisfiedBy(candidate);
+			Assert.False(allowed);
+		}
+		class Dictionary : Dictionary<string, string> {}
 	}
 }

--- a/test/ExtendedXmlSerializerTest/ContentModel/Members/BlacklistMemberPolicyTests.cs
+++ b/test/ExtendedXmlSerializerTest/ContentModel/Members/BlacklistMemberPolicyTests.cs
@@ -1,0 +1,53 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ExtendedXmlSerialization.ContentModel.Members;
+using ExtendedXmlSerialization.Core;
+using Xunit;
+
+namespace ExtendedXmlSerialization.Test.ContentModel.Members
+{
+	public class BlacklistMemberPolicyTests
+	{
+		[Fact]
+		public void Blacklist()
+		{
+			const string name = nameof(IDictionary<object, object>.Keys);
+			var ignore = typeof(IDictionary<,>).GetRuntimeProperty(name);
+			var sut = new BlacklistMemberPolicy(ignore);
+			var instance = new Dictionary<string, int>();
+			var type = instance.GetType();
+			var candidate = type.GetRuntimeProperty(name);
+			var allowed = sut.IsSatisfiedBy(candidate);
+			Assert.False(allowed);
+
+			foreach (var property in type.GetRuntimeProperties().Except(candidate.Yield()))
+			{
+				Assert.True(sut.IsSatisfiedBy(property));
+			}
+		}
+	}
+}

--- a/test/ExtendedXmlSerializerTest/ContentModel/Members/MemberSourceTests.cs
+++ b/test/ExtendedXmlSerializerTest/ContentModel/Members/MemberSourceTests.cs
@@ -33,18 +33,18 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 		public void XmlElementAttribute()
 		{
 			var expected = new TestClassWithXmlElementAttribute {Id = 123};
-            var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
-                expected,
-                @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassWithXmlElementAttribute xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Identifier>123</Identifier></TestClassWithXmlElementAttribute>"
-            );
-            Assert.Equal(expected.Id, actual.Id);
+			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+				expected,
+				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassWithXmlElementAttribute xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Identifier>123</Identifier></TestClassWithXmlElementAttribute>"
+			);
+			Assert.Equal(expected.Id, actual.Id);
 		}
 
 		[Fact]
 		public void XmlElementWithOrder()
 		{
 			var expected = new TestClassWithOrderParameters {A = "A", B = "B"};
-			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+			var actual = SerializationSupport.Default.Assert(
 				expected,
 				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassWithOrderParameters xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><A>A</A><B>B</B></TestClassWithOrderParameters>"
 			);
@@ -56,7 +56,7 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 		public void XmlElementWithOrderExt()
 		{
 			var expected = new TestClassWithOrderParametersExt {A = "A", B = "B", C = "C", D = "D"};
-			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+			var actual = SerializationSupport.Default.Assert(
 				expected,
 				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassWithOrderParametersExt xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><A>A</A><B>B</B><D>D</D><C>C</C></TestClassWithOrderParametersExt>"
 			);
@@ -70,7 +70,7 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 		public void TestClassInheritanceWithOrder()
 		{
 			var expected = TestObject.TestClassInheritanceWithOrder.Create();
-			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+			var actual = SerializationSupport.Default.Assert(
 				expected,
 				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassInheritanceWithOrder xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Id2>3</Id2><Id>2</Id></TestClassInheritanceWithOrder>"
 			);
@@ -82,7 +82,7 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 		public void TestClassInterfaceInheritanceWithOrder()
 		{
 			var expected = new TestClassInterfaceInheritanceWithOrder {Id = 1, Id2 = 2};
-			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+			var actual = SerializationSupport.Default.Assert(
 				expected,
 				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassInterfaceInheritanceWithOrder xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Id2>2</Id2><Id>1</Id></TestClassInterfaceInheritanceWithOrder>"
 			);
@@ -94,7 +94,7 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 		public void XmlRoot()
 		{
 			var expected = new TestClassWithXmlRootAttribute {Id = 123};
-			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+			var actual = SerializationSupport.Default.Assert(
 				expected,
 				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClass xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Id>123</Id></TestClass>"
 			);

--- a/test/ExtendedXmlSerializerTest/ContentModel/Members/MemberSourceTests.cs
+++ b/test/ExtendedXmlSerializerTest/ContentModel/Members/MemberSourceTests.cs
@@ -33,7 +33,7 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Members
 		public void XmlElementAttribute()
 		{
 			var expected = new TestClassWithXmlElementAttribute {Id = 123};
-			var actual = ExtendedXmlSerializerTestSupport.Default.Assert(
+			var actual = SerializationSupport.Default.Assert(
 				expected,
 				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassWithXmlElementAttribute xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Identifier>123</Identifier></TestClassWithXmlElementAttribute>"
 			);

--- a/test/ExtendedXmlSerializerTest/ContentModel/Xml/AssemblyPartitionedTypesTests.cs
+++ b/test/ExtendedXmlSerializerTest/ContentModel/Xml/AssemblyPartitionedTypesTests.cs
@@ -22,10 +22,11 @@
 // SOFTWARE.
 
 using System.Reflection;
-using System.Xml.Linq;
+using ExtendedXmlSerialization.ContentModel;
 using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
 using Xunit;
+using TypeFormatter = ExtendedXmlSerialization.ContentModel.Xml.TypeFormatter;
 
 namespace ExtendedXmlSerialization.Test.ContentModel.Xml
 {
@@ -36,7 +37,7 @@ namespace ExtendedXmlSerialization.Test.ContentModel.Xml
 		{
 			var expected = typeof(Subject).GetTypeInfo();
 			var @namespace = NamespaceFormatter.Default.Get(expected);
-			var type = AssemblyPartitionedTypes.Default.Get(XName.Get(TypeFormatter.Default.Get(expected), @namespace));
+			var type = AssemblyPartitionedTypes.Default.Get(new Identity(TypeFormatter.Default.Get(expected), @namespace));
 			Assert.Equal(expected, type);
 		}
 

--- a/test/ExtendedXmlSerializerTest/ContentModel/Xml/PartitionedTypesTests.cs
+++ b/test/ExtendedXmlSerializerTest/ContentModel/Xml/PartitionedTypesTests.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,39 +21,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
 using System.Reflection;
+using ExtendedXmlSerialization.ContentModel;
+using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
+using Xunit;
+using TypeFormatter = ExtendedXmlSerialization.ContentModel.Xml.TypeFormatter;
 
-namespace ExtendedXmlSerialization.TypeModel
+namespace ExtendedXmlSerialization.Test.ContentModel.Xml
 {
-	public class ImplementedTypeComparer : ITypeComparer
+	public class PartitionedTypesTests
 	{
-		public static ImplementedTypeComparer Default { get; } = new ImplementedTypeComparer();
-		ImplementedTypeComparer() : this(InterfaceIdentities.Default, TypeDefinitionIdentityComparer.Default) {}
-
-		readonly IInterfaceIdentities _interfaces;
-		readonly ITypeComparer _identity;
-
-		public ImplementedTypeComparer(IInterfaceIdentities interfaces, ITypeComparer identity)
+		[Fact]
+		public void TestName()
 		{
-			_interfaces = interfaces;
-			_identity = identity;
+			var expected = typeof(Subject).GetTypeInfo();
+			var @namespace = NamespaceFormatter.Default.Get(expected);
+			var type = PartitionedTypes.Default.Get(new Identity(TypeFormatter.Default.Get(expected), @namespace));
+			Assert.Equal(expected, type);
 		}
 
-		public bool Equals(TypeInfo x, TypeInfo y)
-		{
-			var left = x.IsInterface;
-			if (left != y.IsInterface)
-			{
-				var @interface = left ? x : y;
-				var implementation = left ? y : x;
-				var contains = _interfaces.Get(implementation).Contains(@interface.GUID);
-				return contains;
-			}
-			var result = _identity.Equals(x, y);
-			return result;
-		}
-
-		public int GetHashCode(TypeInfo obj) => 0;
+		sealed class Subject {}
 	}
 }

--- a/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
@@ -35,6 +35,7 @@ namespace ExtendedXmlSerialization.Test
 {
 	public class ExtendedXmlSerializerTests
 	{
+		const string HelloWorld = "Hello World!";
 		readonly IExtendedXmlSerializer _serializer = new ExtendedXmlConfiguration().Create();
 
 		[Fact]
@@ -53,21 +54,21 @@ namespace ExtendedXmlSerialization.Test
 		[Fact]
 		public void SimpleInstance()
 		{
-			var instance = new SimpleNestedClass {PropertyName = "Hello World!"};
+			var instance = new SimpleNestedClass {PropertyName = HelloWorld};
 			var data = _serializer.Serialize(instance);
 			Assert.Equal(
 				@"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-SimpleNestedClass xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest""><PropertyName>Hello World!</PropertyName></ExtendedXmlSerializerTests-SimpleNestedClass>",
 				data);
 			var read = _serializer.Deserialize<SimpleNestedClass>(data);
 			Assert.NotNull(read);
-			Assert.Equal("Hello World!", read.PropertyName);
+			Assert.Equal(HelloWorld, read.PropertyName);
 		}
 
 		[Fact]
 		public void ComplexInstance()
 		{
 			const string expected =
-				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassOtherClass xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Other><Test><Id>2</Id><Name>Other Name</Name></Test><Double>7.3453145324</Double></Other><Primitive1><PropString>TestString</PropString><PropInt>-1</PropInt><PropuInt>2234</PropuInt><PropDecimal>3.346</PropDecimal><PropDecimalMinValue>-79228162514264337593543950335</PropDecimalMinValue><PropDecimalMaxValue>79228162514264337593543950335</PropDecimalMaxValue><PropFloat>7.4432</PropFloat><PropFloatNaN>NaN</PropFloatNaN><PropFloatPositiveInfinity>INF</PropFloatPositiveInfinity><PropFloatNegativeInfinity>-INF</PropFloatNegativeInfinity><PropFloatMinValue>-3.40282347E+38</PropFloatMinValue><PropFloatMaxValue>3.40282347E+38</PropFloatMaxValue><PropDouble>3.4234</PropDouble><PropDoubleNaN>NaN</PropDoubleNaN><PropDoublePositiveInfinity>INF</PropDoublePositiveInfinity><PropDoubleNegativeInfinity>-INF</PropDoubleNegativeInfinity><PropDoubleMinValue>-1.7976931348623157E+308</PropDoubleMinValue><PropDoubleMaxValue>1.7976931348623157E+308</PropDoubleMaxValue><PropEnum>EnumValue1</PropEnum><PropLong>234234142</PropLong><PropUlong>2345352534</PropUlong><PropShort>23</PropShort><PropUshort>2344</PropUshort><PropDateTime>2014-01-23T00:00:00</PropDateTime><PropByte>23</PropByte><PropSbyte>33</PropSbyte><PropChar>g</PropChar></Primitive1><Primitive2><PropString>TestString</PropString><PropInt>-1</PropInt><PropuInt>2234</PropuInt><PropDecimal>3.346</PropDecimal><PropDecimalMinValue>-79228162514264337593543950335</PropDecimalMinValue><PropDecimalMaxValue>79228162514264337593543950335</PropDecimalMaxValue><PropFloat>7.4432</PropFloat><PropFloatNaN>NaN</PropFloatNaN><PropFloatPositiveInfinity>INF</PropFloatPositiveInfinity><PropFloatNegativeInfinity>-INF</PropFloatNegativeInfinity><PropFloatMinValue>-3.40282347E+38</PropFloatMinValue><PropFloatMaxValue>3.40282347E+38</PropFloatMaxValue><PropDouble>3.4234</PropDouble><PropDoubleNaN>NaN</PropDoubleNaN><PropDoublePositiveInfinity>INF</PropDoublePositiveInfinity><PropDoubleNegativeInfinity>-INF</PropDoubleNegativeInfinity><PropDoubleMinValue>-1.7976931348623157E+308</PropDoubleMinValue><PropDoubleMaxValue>1.7976931348623157E+308</PropDoubleMaxValue><PropEnum>EnumValue1</PropEnum><PropLong>234234142</PropLong><PropUlong>2345352534</PropUlong><PropShort>23</PropShort><PropUshort>2344</PropUshort><PropDateTime>2014-01-23T00:00:00</PropDateTime><PropByte>23</PropByte><PropSbyte>33</PropSbyte><PropChar>g</PropChar></Primitive2><ListProperty><TestClassItem><Id>0</Id><Name>Name 000</Name></TestClassItem><TestClassItem><Id>1</Id><Name>Name 001</Name></TestClassItem><TestClassItem><Id>2</Id><Name>Name 002</Name></TestClassItem><TestClassItem><Id>3</Id><Name>Name 003</Name></TestClassItem><TestClassItem><Id>4</Id><Name>Name 004</Name></TestClassItem><TestClassItem><Id>5</Id><Name>Name 005</Name></TestClassItem><TestClassItem><Id>6</Id><Name>Name 006</Name></TestClassItem><TestClassItem><Id>7</Id><Name>Name 007</Name></TestClassItem><TestClassItem><Id>8</Id><Name>Name 008</Name></TestClassItem><TestClassItem><Id>9</Id><Name>Name 009</Name></TestClassItem><TestClassItem><Id>10</Id><Name>Name 0010</Name></TestClassItem><TestClassItem><Id>11</Id><Name>Name 0011</Name></TestClassItem><TestClassItem><Id>12</Id><Name>Name 0012</Name></TestClassItem><TestClassItem><Id>13</Id><Name>Name 0013</Name></TestClassItem><TestClassItem><Id>14</Id><Name>Name 0014</Name></TestClassItem><TestClassItem><Id>15</Id><Name>Name 0015</Name></TestClassItem><TestClassItem><Id>16</Id><Name>Name 0016</Name></TestClassItem><TestClassItem><Id>17</Id><Name>Name 0017</Name></TestClassItem><TestClassItem><Id>18</Id><Name>Name 0018</Name></TestClassItem><TestClassItem><Id>19</Id><Name>Name 0019</Name></TestClassItem></ListProperty></TestClassOtherClass>";
+				@"<?xml version=""1.0"" encoding=""utf-8""?><TestClassOtherClass xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Other><Test><Id>2</Id><Name>Other Name</Name></Test><Double>7.3453145324</Double></Other><Primitive1><PropString>TestString</PropString><PropInt>-1</PropInt><PropuInt>2234</PropuInt><PropDecimal>3.346</PropDecimal><PropDecimalMinValue>-79228162514264337593543950335</PropDecimalMinValue><PropDecimalMaxValue>79228162514264337593543950335</PropDecimalMaxValue><PropFloat>7.4432</PropFloat><PropFloatNaN>NaN</PropFloatNaN><PropFloatPositiveInfinity>INF</PropFloatPositiveInfinity><PropFloatNegativeInfinity>-INF</PropFloatNegativeInfinity><PropFloatMinValue>-3.40282347E+38</PropFloatMinValue><PropFloatMaxValue>3.40282347E+38</PropFloatMaxValue><PropDouble>3.4234</PropDouble><PropDoubleNaN>NaN</PropDoubleNaN><PropDoublePositiveInfinity>INF</PropDoublePositiveInfinity><PropDoubleNegativeInfinity>-INF</PropDoubleNegativeInfinity><PropDoubleMinValue>-1.7976931348623157E+308</PropDoubleMinValue><PropDoubleMaxValue>1.7976931348623157E+308</PropDoubleMaxValue><PropEnum>EnumValue1</PropEnum><PropLong>234234142</PropLong><PropUlong>2345352534</PropUlong><PropShort>23</PropShort><PropUshort>2344</PropUshort><PropDateTime>2014-01-23T00:00:00</PropDateTime><PropByte>23</PropByte><PropSbyte>33</PropSbyte><PropChar>g</PropChar></Primitive1><Primitive2><PropString>TestString</PropString><PropInt>-1</PropInt><PropuInt>2234</PropuInt><PropDecimal>3.346</PropDecimal><PropDecimalMinValue>-79228162514264337593543950335</PropDecimalMinValue><PropDecimalMaxValue>79228162514264337593543950335</PropDecimalMaxValue><PropFloat>7.4432</PropFloat><PropFloatNaN>NaN</PropFloatNaN><PropFloatPositiveInfinity>INF</PropFloatPositiveInfinity><PropFloatNegativeInfinity>-INF</PropFloatNegativeInfinity><PropFloatMinValue>-3.40282347E+38</PropFloatMinValue><PropFloatMaxValue>3.40282347E+38</PropFloatMaxValue><PropDouble>3.4234</PropDouble><PropDoubleNaN>NaN</PropDoubleNaN><PropDoublePositiveInfinity>INF</PropDoublePositiveInfinity><PropDoubleNegativeInfinity>-INF</PropDoubleNegativeInfinity><PropDoubleMinValue>-1.7976931348623157E+308</PropDoubleMinValue><PropDoubleMaxValue>1.7976931348623157E+308</PropDoubleMaxValue><PropEnum>EnumValue1</PropEnum><PropLong>234234142</PropLong><PropUlong>2345352534</PropUlong><PropShort>23</PropShort><PropUshort>2344</PropUshort><PropDateTime>2014-01-23T00:00:00</PropDateTime><PropByte>23</PropByte><PropSbyte>33</PropSbyte><PropChar>g</PropChar></Primitive2><ListProperty><Capacity>32</Capacity><TestClassItem><Id>0</Id><Name>Name 000</Name></TestClassItem><TestClassItem><Id>1</Id><Name>Name 001</Name></TestClassItem><TestClassItem><Id>2</Id><Name>Name 002</Name></TestClassItem><TestClassItem><Id>3</Id><Name>Name 003</Name></TestClassItem><TestClassItem><Id>4</Id><Name>Name 004</Name></TestClassItem><TestClassItem><Id>5</Id><Name>Name 005</Name></TestClassItem><TestClassItem><Id>6</Id><Name>Name 006</Name></TestClassItem><TestClassItem><Id>7</Id><Name>Name 007</Name></TestClassItem><TestClassItem><Id>8</Id><Name>Name 008</Name></TestClassItem><TestClassItem><Id>9</Id><Name>Name 009</Name></TestClassItem><TestClassItem><Id>10</Id><Name>Name 0010</Name></TestClassItem><TestClassItem><Id>11</Id><Name>Name 0011</Name></TestClassItem><TestClassItem><Id>12</Id><Name>Name 0012</Name></TestClassItem><TestClassItem><Id>13</Id><Name>Name 0013</Name></TestClassItem><TestClassItem><Id>14</Id><Name>Name 0014</Name></TestClassItem><TestClassItem><Id>15</Id><Name>Name 0015</Name></TestClassItem><TestClassItem><Id>16</Id><Name>Name 0016</Name></TestClassItem><TestClassItem><Id>17</Id><Name>Name 0017</Name></TestClassItem><TestClassItem><Id>18</Id><Name>Name 0018</Name></TestClassItem><TestClassItem><Id>19</Id><Name>Name 0019</Name></TestClassItem></ListProperty></TestClassOtherClass>";
 			var instance = TestClassOtherClass.Create();
 			var data = _serializer.Serialize(instance);
 
@@ -96,12 +97,64 @@ namespace ExtendedXmlSerialization.Test
 		}
 
 		[Fact]
+		public void ListProperties()
+		{
+			var expected = new ListWithProperties {"Hello", "World", "Hope", "This", "Works!"};
+			expected.Message = HelloWorld;
+			expected.Number = 6776;
+			var data = _serializer.Serialize(expected);
+			var actual = _serializer.Deserialize<ListWithProperties>(data);
+			Assert.Equal(expected, actual);
+			Assert.Equal(HelloWorld, actual.Message);
+			Assert.Equal(6776, actual.Number);
+		}
+
+		[Fact]
+		public void GenericListProperties()
+		{
+			var expected = new ListWithProperties<string> {"Hello", "World", "Hope", "This", "Works!"};
+			expected.Message = HelloWorld;
+			expected.Number = 6776;
+			var data = _serializer.Serialize(expected);
+			var actual = _serializer.Deserialize<ListWithProperties<string>>(data);
+			Assert.Equal(expected, actual);
+			Assert.Equal(HelloWorld, actual.Message);
+			Assert.Equal(6776, actual.Number);
+		}
+
+		[Fact]
 		public void BasicHashSet()
 		{
 			var expected = new HashSet<string> {"Hello", "World", "Hope", "This", "Works!"};
 			var data = _serializer.Serialize(expected);
 			var actual = _serializer.Deserialize<HashSet<string>>(data);
 			Assert.True(actual.SetEquals(expected));
+		}
+
+		[Fact]
+		public void HashSetProperties()
+		{
+			var expected = new HashSetWithProperties {"Hello", "World", "Hope", "This", "Works!"};
+			expected.Message = HelloWorld;
+			expected.Number = 6776;
+			var data = _serializer.Serialize(expected);
+			var actual = _serializer.Deserialize<HashSetWithProperties>(data);
+			Assert.True(actual.SetEquals(expected));
+			Assert.Equal(HelloWorld, actual.Message);
+			Assert.Equal(6776, actual.Number);
+		}
+
+		[Fact]
+		public void GenericHashSetWithProperties()
+		{
+			var expected = new HashSetWithProperties<string> {"Hello", "World", "Hope", "This", "Works!"};
+			expected.Message = HelloWorld;
+			expected.Number = 6776;
+			var data = _serializer.Serialize(expected);
+			var actual = _serializer.Deserialize<HashSetWithProperties<string>>(data);
+			Assert.True(actual.SetEquals(expected));
+			Assert.Equal(HelloWorld, actual.Message);
+			Assert.Equal(6776, actual.Number);
 		}
 
 		[Fact]
@@ -120,6 +173,96 @@ namespace ExtendedXmlSerialization.Test
 			{
 				Assert.Equal(expected[entry.Key], entry.Value);
 			}
+		}
+
+		[Fact]
+		public void DictionaryProperties()
+		{
+			var expected = new DictionaryWithProperties
+			               {
+				               {"First", 1},
+				               {"Second", 2},
+				               {"Other", 3}
+			               };
+			expected.Message = HelloWorld;
+			expected.Number = 6776;
+
+			var data = _serializer.Serialize(expected);
+			var actual = _serializer.Deserialize<DictionaryWithProperties>(data);
+			Assert.NotNull(actual);
+			Assert.Equal(HelloWorld, actual.Message);
+			Assert.Equal(6776, actual.Number);
+			Assert.Equal(expected.Count, actual.Count);
+			foreach (var entry in actual)
+			{
+				Assert.Equal(expected[entry.Key], entry.Value);
+			}
+		}
+
+		[Fact]
+		public void GenericDictionaryProperties()
+		{
+			var expected = new GenericDictionaryWithProperties<int, string>
+			               {
+				               {1, "First"},
+				               {2, "Second"},
+				               {3, "Other"}
+			               };
+			expected.Message = HelloWorld;
+			expected.Number = 6776;
+
+			var data = _serializer.Serialize(expected);
+			var actual = _serializer.Deserialize<GenericDictionaryWithProperties<int, string>>(data);
+			Assert.NotNull(actual);
+			Assert.Equal(HelloWorld, actual.Message);
+			Assert.Equal(6776, actual.Number);
+			Assert.Equal(expected.Count, actual.Count);
+			foreach (var entry in actual)
+			{
+				Assert.Equal(expected[entry.Key], entry.Value);
+			}
+		}
+
+		public class ListWithProperties : List<string>
+		{
+			public string Message { get; set; }
+
+			public int Number { get; set; }
+		}
+
+		public class ListWithProperties<T> : List<T>
+		{
+			public string Message { get; set; }
+
+			public int Number { get; set; }
+		}
+
+		public class HashSetWithProperties<T> : HashSet<T>
+		{
+			public string Message { get; set; }
+
+			public int Number { get; set; }
+		}
+
+		public class HashSetWithProperties : HashSet<string>
+		{
+			public string Message { get; set; }
+
+			public int Number { get; set; }
+		}
+
+		public class GenericDictionaryWithProperties<TKey, TValue> : Dictionary<TKey, TValue>
+		{
+			public string Message { get; set; }
+
+			public int Number { get; set; }
+		}
+
+		public class DictionaryWithProperties : Dictionary<string, int>
+		{
+			public string Message { get; set; }
+
+			public int Number { get; set; }
 		}
 
 		[Fact]

--- a/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
@@ -25,6 +25,8 @@
 
 using System.Collections.Generic;
 using ExtendedXmlSerialization.Configuration;
+using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.ContentModel.Xml.Namespacing;
 using ExtendedXmlSerialization.Test.TestObject;
 using Xunit;
@@ -152,9 +154,22 @@ namespace ExtendedXmlSerialization.Test
 			const string message = "Hello World!  This is a value set in a property with a variable type.", 
 				expected = @"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2""><Interface exs:type=""ExtendedXmlSerializerTests-Implementation""><PropertyName>Hello World!  This is a value set in a property with a variable type.</PropertyName></Interface></ExtendedXmlSerializerTests-ClassWithDifferingPropertyType>";
 			var instance = new ClassWithDifferingPropertyType { Interface = new Implementation { PropertyName = message } };
-			var serializer = new ExtendedXmlSerializer(new OptimizedXmlFactory());
+			var serializer = new ExtendedXmlConfiguration(Factory.Default).Create();
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
+		}
+
+		class Factory : IExtendedXmlSerializerFactory
+		{
+			public static Factory Default { get; } = new Factory();
+			Factory() {}
+
+			public IExtendedXmlSerializer Get(IExtendedXmlConfiguration parameter)
+			{
+				var serializers = new Serializers(Defaults.Property, Defaults.Field);
+				var result = new ExtendedXmlSerializer(TypeSelector.Default, new OptimizedXmlFactory(serializers), serializers);
+				return result;
+			}
 		}
 
 #if CORE
@@ -163,7 +178,7 @@ namespace ExtendedXmlSerialization.Test
 		{
 			const string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest"" xmlns:ns1=""clr-namespace:System.Collections.Generic;assembly=System.Collections"" xmlns:sys=""https://github.com/wojtpl2/ExtendedXmlSerializer/system"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2""><Interface exs:type=""ExtendedXmlSerializerTests-GeneralImplementation""><Instance exs:type=""ns1:HashSet[sys:string]""><sys:string>Hello</sys:string><sys:string>World</sys:string><sys:string>Hope</sys:string><sys:string>This</sys:string><sys:string>Works!</sys:string></Instance></Interface></ExtendedXmlSerializerTests-ClassWithDifferingPropertyType>";
 			var instance = new ClassWithDifferingPropertyType { Interface = new GeneralImplementation { Instance = new HashSet<string> {"Hello", "World", "Hope", "This", "Works!"} } };
-			var serializer = new ExtendedXmlSerializer(new OptimizedXmlFactory());
+			var serializer = new ExtendedXmlConfiguration(Factory.Default).Create();
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
 		}
@@ -173,7 +188,7 @@ namespace ExtendedXmlSerialization.Test
 		{
 			const string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest"" xmlns:ns1=""clr-namespace:System.Collections.Generic;assembly=System.Core"" xmlns:sys=""https://github.com/wojtpl2/ExtendedXmlSerializer/system"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2""><Interface exs:type=""ExtendedXmlSerializerTests-GeneralImplementation""><Instance exs:type=""ns1:HashSet[sys:string]""><sys:string>Hello</sys:string><sys:string>World</sys:string><sys:string>Hope</sys:string><sys:string>This</sys:string><sys:string>Works!</sys:string></Instance></Interface></ExtendedXmlSerializerTests-ClassWithDifferingPropertyType>";
 			var instance = new ClassWithDifferingPropertyType { Interface = new GeneralImplementation { Instance = new HashSet<string> {"Hello", "World", "Hope", "This", "Works!"} } };
-			var serializer = new ExtendedXmlSerializer(new OptimizedXmlFactory());
+			var serializer = new ExtendedXmlConfiguration(Factory.Default).Create();
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
 		}

--- a/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtendedXmlSerializerTests.cs
@@ -152,7 +152,7 @@ namespace ExtendedXmlSerialization.Test
 			const string message = "Hello World!  This is a value set in a property with a variable type.", 
 				expected = @"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2""><Interface exs:type=""ExtendedXmlSerializerTests-Implementation""><PropertyName>Hello World!  This is a value set in a property with a variable type.</PropertyName></Interface></ExtendedXmlSerializerTests-ClassWithDifferingPropertyType>";
 			var instance = new ClassWithDifferingPropertyType { Interface = new Implementation { PropertyName = message } };
-			var serializer = new ExtendedXmlSerializer(new OptimizedXmlWriterFactory());
+			var serializer = new ExtendedXmlSerializer(new OptimizedXmlFactory());
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
 		}
@@ -163,7 +163,7 @@ namespace ExtendedXmlSerialization.Test
 		{
 			const string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest"" xmlns:ns1=""clr-namespace:System.Collections.Generic;assembly=System.Collections"" xmlns:sys=""https://github.com/wojtpl2/ExtendedXmlSerializer/system"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2""><Interface exs:type=""ExtendedXmlSerializerTests-GeneralImplementation""><Instance exs:type=""ns1:HashSet[sys:string]""><sys:string>Hello</sys:string><sys:string>World</sys:string><sys:string>Hope</sys:string><sys:string>This</sys:string><sys:string>Works!</sys:string></Instance></Interface></ExtendedXmlSerializerTests-ClassWithDifferingPropertyType>";
 			var instance = new ClassWithDifferingPropertyType { Interface = new GeneralImplementation { Instance = new HashSet<string> {"Hello", "World", "Hope", "This", "Works!"} } };
-			var serializer = new ExtendedXmlSerializer(new OptimizedXmlWriterFactory());
+			var serializer = new ExtendedXmlSerializer(new OptimizedXmlFactory());
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
 		}
@@ -173,7 +173,7 @@ namespace ExtendedXmlSerialization.Test
 		{
 			const string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><ExtendedXmlSerializerTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test;assembly=ExtendedXmlSerializerTest"" xmlns:ns1=""clr-namespace:System.Collections.Generic;assembly=System.Core"" xmlns:sys=""https://github.com/wojtpl2/ExtendedXmlSerializer/system"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2""><Interface exs:type=""ExtendedXmlSerializerTests-GeneralImplementation""><Instance exs:type=""ns1:HashSet[sys:string]""><sys:string>Hello</sys:string><sys:string>World</sys:string><sys:string>Hope</sys:string><sys:string>This</sys:string><sys:string>Works!</sys:string></Instance></Interface></ExtendedXmlSerializerTests-ClassWithDifferingPropertyType>";
 			var instance = new ClassWithDifferingPropertyType { Interface = new GeneralImplementation { Instance = new HashSet<string> {"Hello", "World", "Hope", "This", "Works!"} } };
-			var serializer = new ExtendedXmlSerializer(new OptimizedXmlWriterFactory());
+			var serializer = new ExtendedXmlSerializer(new OptimizedXmlFactory());
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
 		}

--- a/test/ExtendedXmlSerializerTest/Support/SerializationSupport.cs
+++ b/test/ExtendedXmlSerializerTest/Support/SerializationSupport.cs
@@ -1,11 +1,12 @@
 ﻿using System.IO;
+using ExtendedXmlSerialization.Configuration;
 
 namespace ExtendedXmlSerialization.Test.Support
 {
 	class SerializationSupport : IExtendedXmlSerializerTestSupport
 	{
 		public static SerializationSupport Default { get; } = new SerializationSupport();
-		SerializationSupport() : this(new ExtendedXmlSerializer()) {}
+		SerializationSupport() : this(new ExtendedXmlConfiguration().Create()) {}
 
 		readonly IExtendedXmlSerializer _serializer;
 

--- a/test/ExtendedXmlSerializerTest/Support/SerializationSupport.cs
+++ b/test/ExtendedXmlSerializerTest/Support/SerializationSupport.cs
@@ -2,14 +2,14 @@
 
 namespace ExtendedXmlSerialization.Test.Support
 {
-	class ExtendedXmlSerializerTestSupport : IExtendedXmlSerializerTestSupport
+	class SerializationSupport : IExtendedXmlSerializerTestSupport
 	{
-		public static ExtendedXmlSerializerTestSupport Default { get; } = new ExtendedXmlSerializerTestSupport();
-		ExtendedXmlSerializerTestSupport() : this(new ExtendedXmlSerializer()) {}
+		public static SerializationSupport Default { get; } = new SerializationSupport();
+		SerializationSupport() : this(new ExtendedXmlSerializer()) {}
 
 		readonly IExtendedXmlSerializer _serializer;
 
-		protected ExtendedXmlSerializerTestSupport(IExtendedXmlSerializer serializer)
+		protected SerializationSupport(IExtendedXmlSerializer serializer)
 		{
 			_serializer = serializer;
 		}

--- a/test/ExtendedXmlSerializerTest/TypeModel/ImplementedTypeComparerTests.cs
+++ b/test/ExtendedXmlSerializerTest/TypeModel/ImplementedTypeComparerTests.cs
@@ -41,5 +41,16 @@ namespace ExtendedXmlSerialization.Test.TypeModel
 
 			Assert.Equal(expected, actual, sut);
 		}
+
+		[Fact]
+		public void Inherited()
+		{
+			var expected = typeof(IDictionary<,>).GetTypeInfo();
+			var sut = ImplementedTypeComparer.Default;
+
+			Assert.Equal(expected, typeof(Dictionary).GetTypeInfo(), sut);
+		}
+
+		class Dictionary : Dictionary<string, string> {}
 	}
 }

--- a/test/ExtendedXmlSerializerTest/TypeModel/ImplementedTypeComparerTests.cs
+++ b/test/ExtendedXmlSerializerTest/TypeModel/ImplementedTypeComparerTests.cs
@@ -1,0 +1,45 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using ExtendedXmlSerialization.TypeModel;
+using Xunit;
+
+namespace ExtendedXmlSerialization.Test.TypeModel
+{
+	public class ImplementedTypeComparerTests
+	{
+		[Fact]
+		public void Verify()
+		{
+			var expected = typeof(IDictionary<,>).GetTypeInfo();
+			var actual = typeof(Dictionary<,>).GetInterfaces().First().GetTypeInfo();
+			
+			var sut = ImplementedTypeComparer.Default;
+
+			Assert.Equal(expected, actual, sut);
+		}
+	}
+}

--- a/test/ExtendedXmlSerializerTest/TypeModel/MemberComparerTests.cs
+++ b/test/ExtendedXmlSerializerTest/TypeModel/MemberComparerTests.cs
@@ -1,0 +1,116 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using ExtendedXmlSerialization.TypeModel;
+using Xunit;
+
+namespace ExtendedXmlSerialization.Test.TypeModel
+{
+	[SuppressMessage("ReSharper", "UnusedMember.Local")]
+	[SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
+	public class MemberComparerTests
+	{
+		[Fact]
+		public void Interface()
+		{
+			const string keys = nameof(IDictionary.Keys), values = nameof(IDictionary.Values);
+			var definition = typeof(IDictionary<,>).GetRuntimeProperty(keys);
+
+			var sut = new MemberComparer(ImplementedTypeComparer.Default);
+
+			var constructed = typeof(IDictionary<string, int>);
+			Assert.Equal(definition, constructed.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, constructed.GetRuntimeProperty(values), sut);
+
+			var implementation = typeof(Dictionary<string, int>);
+			Assert.Equal(definition, implementation.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, implementation.GetRuntimeProperty(values), sut);
+
+			var not = typeof(NotDictionary<,>);
+			Assert.NotEqual(definition, not.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, not.GetRuntimeProperty(values), sut);
+
+			var notConstructed = typeof(NotDictionary<string, int>);
+			Assert.NotEqual(definition, notConstructed.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, notConstructed.GetRuntimeProperty(values), sut);
+		}
+
+
+		[Fact]
+		public void Definition()
+		{
+			const string keys = nameof(IDictionary.Keys), values = nameof(IDictionary.Values);
+			var definition = typeof(Dictionary<,>).GetRuntimeProperty(keys);
+
+			var sut = new MemberComparer(ImplementedTypeComparer.Default);
+
+			var constructed = typeof(Dictionary<string, int>);
+			Assert.Equal(definition, constructed.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, constructed.GetRuntimeProperty(values), sut);
+
+			var not = typeof(NotDictionary<,>);
+			Assert.NotEqual(definition, not.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, not.GetRuntimeProperty(values), sut);
+
+			var notConstructed = typeof(NotDictionary<string, int>);
+			Assert.NotEqual(definition, notConstructed.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, notConstructed.GetRuntimeProperty(values), sut);
+		}
+
+		[Fact]
+		public void Explicit()
+		{
+			const string keys = nameof(IDictionary.Keys), values = nameof(IDictionary.Values);
+			var definition = typeof(Dictionary<string, object>).GetRuntimeProperty(keys);
+
+			var sut = new MemberComparer(TypeIdentityComparer.Default);
+
+			var other = typeof(Dictionary<string, int>);
+			Assert.NotEqual(definition, other.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, other.GetRuntimeProperty(values), sut);
+
+			var implementation = typeof(Dictionary<string, object>);
+			Assert.Equal(definition, implementation.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, implementation.GetRuntimeProperty(values), sut);
+
+			var not = typeof(NotDictionary<,>);
+			Assert.NotEqual(definition, not.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, not.GetRuntimeProperty(values), sut);
+
+			var notConstructed = typeof(NotDictionary<string, int>);
+			Assert.NotEqual(definition, notConstructed.GetRuntimeProperty(keys), sut);
+			Assert.NotEqual(definition, notConstructed.GetRuntimeProperty(values), sut);
+		}
+
+		class NotDictionary<TKey, TValue>
+		{
+			public ICollection<TKey> Keys { get; }
+
+			public ICollection<TValue> Values { get; }
+		}
+	}
+}

--- a/test/ExtendedXmlSerializerTest/TypeModel/TypeDefinitionIdentityComparerTests.cs
+++ b/test/ExtendedXmlSerializerTest/TypeModel/TypeDefinitionIdentityComparerTests.cs
@@ -21,27 +21,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using ExtendedXmlSerialization.Core;
-using ExtendedXmlSerialization.Core.Sources;
+using ExtendedXmlSerialization.TypeModel;
+using Xunit;
 
-namespace ExtendedXmlSerialization.ContentModel.Content
+namespace ExtendedXmlSerialization.Test.TypeModel
 {
-	sealed class ContainerSelector : Selector<TypeInfo, ISerializer>, IContainers
+	public class TypeDefinitionIdentityComparerTests
 	{
-		readonly IParameterizedSource<TypeInfo, ISerializer> _content;
-
-		public ContainerSelector(params ContainerDefinition[] definitions)
-			: this(
-				new Selector<TypeInfo, ISerializer>(definitions.Select(x => x.Content).ToArray()).Cache(), definitions) {}
-
-		public ContainerSelector(IParameterizedSource<TypeInfo, ISerializer> content, params ContainerDefinition[] definitions)
-			: base(definitions.Select(x => new ContainerOption(x.Element, x.Content)).ToArray())
+		[Fact]
+		public void Verify()
 		{
-			_content = content;
-		}
+			var expected = typeof(IDictionary<,>).GetTypeInfo();
+			var actual = typeof(Dictionary<,>).GetInterfaces().First().GetTypeInfo();
+			Assert.NotStrictEqual(expected, actual);
+			Assert.NotSame(expected, actual);
 
-		public ISerializer Content(TypeInfo parameter) => _content.Get(parameter);
+			var sut = TypeDefinitionIdentityComparer.Default;
+
+			Assert.Equal(expected, actual, sut);
+			var info = typeof(IDictionary<object, object>).GetTypeInfo();
+
+			Assert.NotStrictEqual(expected, info);
+			Assert.Equal(expected, info, sut);
+
+			Assert.False(typeof(IDictionary<,>).IsAssignableFrom(typeof(Dictionary<,>)));
+			Assert.True(typeof(IDictionary<string, object>).IsAssignableFrom(typeof(Dictionary<string, object>)));
+		}
 	}
 }


### PR DESCRIPTION
Finally, some progress.  That only took four months. 😛 

This PR introduces member support for dictionaries and lists.  Going forward, all objects and types should emit their fields and properties if they are configured to do so.  I have also introduced basic member policies (such as [blacklists](https://github.com/wojtpl2/ExtendedXmlSerializer/compare/v2.0.0...Mike-EEE:feature/properties?expand=1#diff-0a48b2f415cf91e635edb0d273d761f5) and whitelists).  These of course will be used in the ConfigurationAPI.  Currently the [default policy is a blacklist](https://github.com/wojtpl2/ExtendedXmlSerializer/compare/v2.0.0...Mike-EEE:feature/properties?expand=1#diff-99cb487bd4a2a2ee2e6a3453cec4d4e4R39) that keeps dictionary keys and values from being emitted, as these are taken care of with the default write behavior of the dictionary class.