### PR TITLE
Feature/circular reference checking

### DIFF
--- a/src/ExtendedXmlSerializer/ContentModel/Content/VariableTypeElementOption.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Content/VariableTypeElementOption.cs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 using System.Reflection;
-using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Content
@@ -30,7 +29,7 @@ namespace ExtendedXmlSerialization.ContentModel.Content
 	class VariableTypeElementOption : NamedElementOptionBase
 	{
 		readonly Xml.IIdentities _identities;
-		readonly static ISpecification<TypeInfo> Specification = FixedTypeSpecification.Default.Inverse();
+		readonly static ISpecification<TypeInfo> Specification = Core.Specifications.VariableTypeSpecification.Default;
 
 		public static VariableTypeElementOption Default { get; } = new VariableTypeElementOption();
 		VariableTypeElementOption() : this(Xml.Identities.Default) {}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/InstanceMemberWalkerBase.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/InstanceMemberWalkerBase.cs
@@ -28,11 +28,11 @@ using ExtendedXmlSerialization.Core;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
 {
-	public abstract class MemberWalkerBase<T> : ObjectWalkerBase<object, IEnumerable<T>>
+	public abstract class InstanceMemberWalkerBase<T> : ObjectWalkerBase<object, IEnumerable<T>>
 	{
 		readonly IMembers _members;
 
-		protected MemberWalkerBase(IMembers members, object root) : base(root)
+		protected InstanceMemberWalkerBase(IMembers members, object root) : base(root)
 		{
 			_members = members;
 		}

--- a/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMemberSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/VariableTypeMemberSpecification.cs
@@ -22,7 +22,6 @@
 // SOFTWARE.
 
 using System.Reflection;
-using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ContentModel.Members
@@ -32,10 +31,10 @@ namespace ExtendedXmlSerialization.ContentModel.Members
 		readonly static AssignableMemberSpecification Specification = AssignableMemberSpecification.Default;
 
 		public static VariableTypeMemberSpecification Default { get; } = new VariableTypeMemberSpecification();
-		VariableTypeMemberSpecification() : this(FixedTypeSpecification.Default.Inverse()) {}
+		VariableTypeMemberSpecification() : this(VariableTypeSpecification.Default) {}
 
 		readonly ISpecification<TypeInfo> _variable;
-		
+
 		public VariableTypeMemberSpecification(ISpecification<TypeInfo> variable) : base(Specification)
 		{
 			_variable = variable;

--- a/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/RuntimeSerializer.cs
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+using System;
 using System.Reflection;
 using ExtendedXmlSerialization.ContentModel.Content;
 using ExtendedXmlSerialization.ContentModel.Xml;
@@ -41,6 +42,10 @@ namespace ExtendedXmlSerialization.ContentModel
 			var typeInfo = instance.GetType().GetTypeInfo();
 			var container = _serialization.Get(typeInfo);
 			var serializer = container.Get();
+			if (serializer is RuntimeSerializer)
+			{
+				throw new InvalidOperationException($"Could not locate the appropriate serializer for {typeInfo}.");
+			}
 			serializer.Write(writer, instance);
 		}
 

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/ObjectTypeWalker.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/ObjectTypeWalker.cs
@@ -30,7 +30,7 @@ using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ContentModel.Xml
 {
-	class ObjectTypeWalker : MemberWalkerBase<TypeInfo>, ISource<IEnumerable<TypeInfo>>
+	class ObjectTypeWalker : InstanceMemberWalkerBase<TypeInfo>, ISource<IEnumerable<TypeInfo>>
 	{
 		public ObjectTypeWalker(IMembers members, object root) : base(members, root) {}
 

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/Types.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/Types.cs
@@ -56,9 +56,6 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 		}
 
 		protected override TypeInfo Create(IIdentity parameter)
-		{
-			var typeInfo = _aliased.Get(parameter) ?? _known.Get(parameter) ?? _partitions.Get(parameter);
-			return typeInfo;
-		}
+			=> _aliased.Get(parameter) ?? _known.Get(parameter) ?? _partitions.Get(parameter);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/XmlFactory.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/XmlFactory.cs
@@ -40,7 +40,7 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 		public IXmlWriter Create(Stream stream, object instance)
 			=> new XmlWriter(System.Xml.XmlWriter.Create(stream, _writerSettings), instance);
 
-		public IXmlReader Create(Stream stream) => 
+		public IXmlReader Create(Stream stream) =>
 			new XmlReader(System.Xml.XmlReader.Create(stream, _readerSettings));
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Xml/XmlWriter.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Xml/XmlWriter.cs
@@ -28,9 +28,10 @@ namespace ExtendedXmlSerialization.ContentModel.Xml
 {
 	class XmlWriter : IXmlWriter
 	{
+		readonly static string Xmlns = XNamespace.Xmlns.NamespaceName;
+
 		readonly System.Xml.XmlWriter _writer;
 		readonly INamespaces _namespaces;
-		readonly static string Xmlns = XNamespace.Xmlns.NamespaceName;
 
 		public XmlWriter(System.Xml.XmlWriter writer, object root) : this(writer, root, new Namespaces()) {}
 

--- a/src/ExtendedXmlSerializer/Core/Specifications/VariableTypeSpecification.cs
+++ b/src/ExtendedXmlSerializer/Core/Specifications/VariableTypeSpecification.cs
@@ -21,29 +21,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
-using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core.Sources;
+using System.Reflection;
 
-namespace ExtendedXmlSerialization.ExtensionModel
+namespace ExtendedXmlSerialization.Core.Specifications
 {
-	sealed class StoredEncounters : ReferenceCacheBase<IXmlWriter, IReferenceEncounters>, IStoredEncounters
+	public class VariableTypeSpecification : InverseSpecification<TypeInfo>
 	{
-		readonly IRootReferences _references;
-		readonly IEntities _entities;
-
-		public StoredEncounters(IRootReferences references, IEntities entities)
-		{
-			_references = references;
-			_entities = entities;
-		}
-
-		protected override IReferenceEncounters Create(IXmlWriter parameter)
-		{
-			var selector = new ReferenceIdentifiers(_entities);
-			var identities = _references.Get(parameter).ToDictionary(x => x, selector.Get);
-			var result = new ReferenceEncounters(identities);
-			return result;
-		}
+		public static VariableTypeSpecification Default { get; } = new VariableTypeSpecification();
+		VariableTypeSpecification() : base(FixedTypeSpecification.Default) {}
 	}
 }

--- a/src/ExtendedXmlSerializer/ExtensionModel/CircularReferencesDetectedException.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/CircularReferencesDetectedException.cs
@@ -21,29 +21,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
+using System;
 using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ExtensionModel
 {
-	sealed class StoredEncounters : ReferenceCacheBase<IXmlWriter, IReferenceEncounters>, IStoredEncounters
+	class CircularReferencesDetectedException : Exception
 	{
-		readonly IRootReferences _references;
-		readonly IEntities _entities;
-
-		public StoredEncounters(IRootReferences references, IEntities entities)
+		public CircularReferencesDetectedException(string message, IXmlWriter writer) : base(message)
 		{
-			_references = references;
-			_entities = entities;
+			Writer = writer;
 		}
 
-		protected override IReferenceEncounters Create(IXmlWriter parameter)
-		{
-			var selector = new ReferenceIdentifiers(_entities);
-			var identities = _references.Get(parameter).ToDictionary(x => x, selector.Get);
-			var result = new ReferenceEncounters(identities);
-			return result;
-		}
+		public IXmlWriter Writer { get; }
 	}
 }

--- a/src/ExtendedXmlSerializer/ExtensionModel/DefaultRegistrationsExtension.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/DefaultRegistrationsExtension.cs
@@ -27,6 +27,7 @@ using ExtendedXmlSerialization.Configuration;
 using ExtendedXmlSerialization.ContentModel;
 using ExtendedXmlSerialization.ContentModel.Content;
 using ExtendedXmlSerialization.ContentModel.Members;
+using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.Core.Sources;
 using LightInject;
 using ContainerOptions = ExtendedXmlSerialization.ContentModel.Content.ContainerOptions;
@@ -64,6 +65,14 @@ namespace ExtendedXmlSerialization.ExtensionModel
 			         .Register<IContentOptions, ContentOptions>()
 			         .Register<IContainerOptions, ContainerOptions>()
 			         .Register(factory => factory.GetInstance<IContainerOptions>().ToArray())
+			         .Register<IStaticReferenceSpecification, ContainsStaticReferenceSpecification>()
+			         .Register<ContainsStaticReferenceSpecification>()
+			         .Register<IRootReferences, RootReferences>()
+			         .Decorate<IXmlFactory>(
+				         (factory, xmlFactory) =>
+					         new ReferentialAwareXmlFactory(factory.GetInstance<IStaticReferenceSpecification>(),
+					                                        factory.GetInstance<IRootReferences>(), xmlFactory)
+			         )
 			         .Register<IExtendedXmlSerializer, ExtendedXmlSerializer>();
 	}
 }

--- a/src/ExtendedXmlSerializer/ExtensionModel/IRootReferences.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/IRootReferences.cs
@@ -21,29 +21,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
+using System.Collections.Generic;
 using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ExtensionModel
 {
-	sealed class StoredEncounters : ReferenceCacheBase<IXmlWriter, IReferenceEncounters>, IStoredEncounters
-	{
-		readonly IRootReferences _references;
-		readonly IEntities _entities;
-
-		public StoredEncounters(IRootReferences references, IEntities entities)
-		{
-			_references = references;
-			_entities = entities;
-		}
-
-		protected override IReferenceEncounters Create(IXmlWriter parameter)
-		{
-			var selector = new ReferenceIdentifiers(_entities);
-			var identities = _references.Get(parameter).ToDictionary(x => x, selector.Get);
-			var result = new ReferenceEncounters(identities);
-			return result;
-		}
-	}
+	public interface IRootReferences : IParameterizedSource<IXmlWriter, IReadOnlyList<object>> {}
 }

--- a/src/ExtendedXmlSerializer/ExtensionModel/IStaticReferenceSpecification.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/IStaticReferenceSpecification.cs
@@ -21,29 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
-using ExtendedXmlSerialization.ContentModel.Xml;
-using ExtendedXmlSerialization.Core.Sources;
+using System.Reflection;
+using ExtendedXmlSerialization.Core.Specifications;
 
 namespace ExtendedXmlSerialization.ExtensionModel
 {
-	sealed class StoredEncounters : ReferenceCacheBase<IXmlWriter, IReferenceEncounters>, IStoredEncounters
-	{
-		readonly IRootReferences _references;
-		readonly IEntities _entities;
-
-		public StoredEncounters(IRootReferences references, IEntities entities)
-		{
-			_references = references;
-			_entities = entities;
-		}
-
-		protected override IReferenceEncounters Create(IXmlWriter parameter)
-		{
-			var selector = new ReferenceIdentifiers(_entities);
-			var identities = _references.Get(parameter).ToDictionary(x => x, selector.Get);
-			var result = new ReferenceEncounters(identities);
-			return result;
-		}
-	}
+	public interface IStaticReferenceSpecification : ISpecification<TypeInfo> {}
 }

--- a/src/ExtendedXmlSerializer/ExtensionModel/ReferenceWalker.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/ReferenceWalker.cs
@@ -30,9 +30,10 @@ using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ExtensionModel
 {
-	class ReferenceWalker : MemberWalkerBase<object>, ISource<IReadOnlyList<object>>
+	class ReferenceWalker : InstanceMemberWalkerBase<object>, ISource<IReadOnlyList<object>>
 	{
 		readonly static IEnumerable<object> Empty = Enumerable.Empty<object>();
+
 		public ReferenceWalker(IMembers members, object root) : base(members, root) {}
 
 		protected override IEnumerable<object> Yield(IMember member, object instance)

--- a/src/ExtendedXmlSerializer/ExtensionModel/ReferencesExtension.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/ReferencesExtension.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using ExtendedXmlSerialization.ContentModel;
 using ExtendedXmlSerialization.ContentModel.Content;
+using ExtendedXmlSerialization.ContentModel.Xml;
 using LightInject;
 
 namespace ExtendedXmlSerialization.ExtensionModel
@@ -51,9 +52,10 @@ namespace ExtendedXmlSerialization.ExtensionModel
 			         .Decorate(_decorate)
 			         .Decorate<IContentOptions>(
 				         (factory, options) =>
-					         new AlteredContentOptions(options, factory.GetInstance<ReferencesContentAlteration>()));
+					         new AlteredContentOptions(options, factory.GetInstance<ReferencesContentAlteration>()))
+			         .Decorate<IXmlFactory>((factory, xmlFactory) => new ReferenceSupportedXmlFactory(xmlFactory));
 
-		IActivation Decorate(IServiceFactory factory, IActivation activation)
+		static IActivation Decorate(IServiceFactory factory, IActivation activation)
 			=> new ReferenceActivation(activation, factory.GetInstance<IEntities>());
 	}
 }

--- a/src/ExtendedXmlSerializer/ExtensionModel/RootReferences.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/RootReferences.cs
@@ -21,29 +21,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Linq;
+using System.Collections.Generic;
+using ExtendedXmlSerialization.ContentModel.Members;
 using ExtendedXmlSerialization.ContentModel.Xml;
 using ExtendedXmlSerialization.Core.Sources;
 
 namespace ExtendedXmlSerialization.ExtensionModel
 {
-	sealed class StoredEncounters : ReferenceCacheBase<IXmlWriter, IReferenceEncounters>, IStoredEncounters
+	sealed class RootReferences : ReferenceCacheBase<IXmlWriter, IReadOnlyList<object>>, IRootReferences
 	{
-		readonly IRootReferences _references;
-		readonly IEntities _entities;
+		readonly IMembers _members;
 
-		public StoredEncounters(IRootReferences references, IEntities entities)
+		public RootReferences(IMembers members)
 		{
-			_references = references;
-			_entities = entities;
+			_members = members;
 		}
 
-		protected override IReferenceEncounters Create(IXmlWriter parameter)
-		{
-			var selector = new ReferenceIdentifiers(_entities);
-			var identities = _references.Get(parameter).ToDictionary(x => x, selector.Get);
-			var result = new ReferenceEncounters(identities);
-			return result;
-		}
+		protected override IReadOnlyList<object> Create(IXmlWriter parameter)
+			=> new ReferenceWalker(_members, parameter.Root).Get();
 	}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/ConstructorLocator.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/ConstructorLocator.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,41 +21,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using ExtendedXmlSerialization.ContentModel.Members;
-using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml
+namespace ExtendedXmlSerialization.TypeModel
 {
-	class ObjectTypeWalker : MemberWalkerBase<TypeInfo>, ISource<IEnumerable<TypeInfo>>
+	public class ConstructorLocator : ReferenceCacheBase<TypeInfo, ConstructorInfo>, IConstructorLocator
 	{
-		public ObjectTypeWalker(IMembers members, object root) : base(members, root) {}
+		public static ConstructorLocator Default { get; } = new ConstructorLocator();
+		ConstructorLocator() {}
 
-		protected override IEnumerable<TypeInfo> Yield(IMember member, object instance)
+		protected override ConstructorInfo Create(TypeInfo parameter)
 		{
-			var variable = member.Adapter as IVariableTypeMemberAdapter;
-			if (variable != null)
+			var constructors = parameter.GetConstructors();
+			var length = constructors.Length;
+			for (var i = 0; i < length; i++)
 			{
-				var current = variable.Get(instance);
-				if (Schedule(current) && variable.IsSatisfiedBy(current.GetType()))
+				var constructor = constructors[i];
+				var parameters = constructor.GetParameters();
+				var l = parameters.Length;
+				if (l == 0 || parameters.All(x => x.IsOptional))
 				{
-					yield return Defaults.FrameworkType;
+					return constructor;
 				}
 			}
+			return null;
 		}
-
-		protected override IEnumerable<TypeInfo> Yield(object instance)
-		{
-			Schedule(instance);
-			yield break;
-		}
-
-		protected override IEnumerable<TypeInfo> Members(object input, TypeInfo parameter)
-			=> parameter.Yield().Concat(base.Members(input, parameter));
-
-		public IEnumerable<TypeInfo> Get() => this.SelectMany(x => x).Distinct();
 	}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/IConstructorLocator.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/IConstructorLocator.cs
@@ -1,6 +1,6 @@
-﻿// MIT License
+// MIT License
 // 
-// Copyright (c) 2016 Wojciech Nagórski
+// Copyright (c) 2016 Wojciech Nag�rski
 //                    Michael DeMond
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -21,41 +21,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using ExtendedXmlSerialization.ContentModel.Members;
-using ExtendedXmlSerialization.Core;
 using ExtendedXmlSerialization.Core.Sources;
 
-namespace ExtendedXmlSerialization.ContentModel.Xml
+namespace ExtendedXmlSerialization.TypeModel
 {
-	class ObjectTypeWalker : MemberWalkerBase<TypeInfo>, ISource<IEnumerable<TypeInfo>>
-	{
-		public ObjectTypeWalker(IMembers members, object root) : base(members, root) {}
-
-		protected override IEnumerable<TypeInfo> Yield(IMember member, object instance)
-		{
-			var variable = member.Adapter as IVariableTypeMemberAdapter;
-			if (variable != null)
-			{
-				var current = variable.Get(instance);
-				if (Schedule(current) && variable.IsSatisfiedBy(current.GetType()))
-				{
-					yield return Defaults.FrameworkType;
-				}
-			}
-		}
-
-		protected override IEnumerable<TypeInfo> Yield(object instance)
-		{
-			Schedule(instance);
-			yield break;
-		}
-
-		protected override IEnumerable<TypeInfo> Members(object input, TypeInfo parameter)
-			=> parameter.Yield().Concat(base.Members(input, parameter));
-
-		public IEnumerable<TypeInfo> Get() => this.SelectMany(x => x).Distinct();
-	}
+	public interface IConstructorLocator : IParameterizedSource<TypeInfo, ConstructorInfo> {}
 }

--- a/src/ExtendedXmlSerializer/TypeModel/IsActivatedTypeSpecification.cs
+++ b/src/ExtendedXmlSerializer/TypeModel/IsActivatedTypeSpecification.cs
@@ -21,7 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-using System;
 using System.Reflection;
 using ExtendedXmlSerialization.Core.Specifications;
 
@@ -31,11 +30,18 @@ namespace ExtendedXmlSerialization.TypeModel
 	{
 		readonly static TypeInfo GeneralObject = typeof(object).GetTypeInfo();
 		public static IsActivatedTypeSpecification Default { get; } = new IsActivatedTypeSpecification();
-		IsActivatedTypeSpecification() {}
+		IsActivatedTypeSpecification() : this(ConstructorLocator.Default) {}
+
+		readonly IConstructorLocator _locator;
+
+		public IsActivatedTypeSpecification(IConstructorLocator locator)
+		{
+			_locator = locator;
+		}
 
 		public bool IsSatisfiedBy(TypeInfo parameter)
 			=> parameter.IsValueType ||
 			   !parameter.IsAbstract && parameter.IsClass && !parameter.Equals(GeneralObject) &&
-			   parameter.GetConstructor(Type.EmptyTypes) != null;
+			   _locator.Get(parameter) != null;
 	}
 }

--- a/test/ExtendedXmlSerializerTest/ExtensionModel/ContainsStaticReferenceSpecificationTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtensionModel/ContainsStaticReferenceSpecificationTests.cs
@@ -1,0 +1,145 @@
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Reflection;
+using ExtendedXmlSerialization.ContentModel;
+using ExtendedXmlSerialization.ContentModel.Collections;
+using ExtendedXmlSerialization.Core;
+using ExtendedXmlSerialization.ExtensionModel;
+using ExtendedXmlSerialization.Test.Support;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace ExtendedXmlSerialization.Test.ExtensionModel
+{
+	public class ContainsStaticReferenceSpecificationTests
+	{
+		[Fact]
+		public void VerifyFixed()
+		{
+			using (var services = new ServicesSupport())
+			{
+				var sut = services.Get<ContainsStaticReferenceSpecification>();
+				Assert.False(sut.IsSatisfiedBy(typeof(Fixed).GetTypeInfo()));
+			}
+		}
+
+		[Fact]
+		public void VerifyNonReferencingVariable()
+		{
+			using (var services = new ServicesSupport())
+			{
+				var sut = services.Get<ContainsStaticReferenceSpecification>();
+				Assert.False(sut.IsSatisfiedBy(typeof(NonReferencingVariable).GetTypeInfo()));
+			}
+		}
+
+		[Fact]
+		public void VerifyReferencingVariable()
+		{
+			using (var services = new ServicesSupport())
+			{
+				var sut = services.Get<ContainsStaticReferenceSpecification>();
+				Assert.True(sut.IsSatisfiedBy(typeof(ReferencingVariable).GetTypeInfo()));
+			}
+		}
+
+		[Fact]
+		public void VerifyReferencingVariableWithInterface()
+		{
+			using (var services = new ServicesSupport())
+			{
+				var sut = services.Get<ContainsStaticReferenceSpecification>();
+				Assert.True(sut.IsSatisfiedBy(typeof(ReferencingVariableWithInterface).GetTypeInfo()));
+			}
+		}
+
+		[Fact]
+		public void VerifyIndirectReferencingVariable()
+		{
+			using (var services = new ServicesSupport())
+			{
+				var sut = services.Get<ContainsStaticReferenceSpecification>();
+				Assert.True(sut.IsSatisfiedBy(typeof(IndirectReferencingVariable).GetTypeInfo()));
+			}
+		}
+
+		class ReferencingVariableWithInterface : NonReferencingVariable
+		{
+			[UsedImplicitly]
+			public IWriter Writer { get; set; }
+		}
+
+		class ReferencingVariable : NonReferencingVariable
+		{
+			[UsedImplicitly]
+			public Concrete Concrete { get; set; }
+		}
+
+		class IndirectReferencingVariable : NonReferencingVariable
+		{
+			[UsedImplicitly]
+			public UnrelatedWithRelatedProperty Unrelated { get; set; }
+		}
+
+
+		[UsedImplicitly]
+		class UnrelatedWithRelatedProperty
+		{
+			[UsedImplicitly]
+			public AbstractBase AbstractBase { get; set; }
+		}
+
+		sealed class Fixed
+		{
+			[UsedImplicitly]
+			public string String { get; set; }
+
+			[UsedImplicitly]
+			public double Double { get; set; }
+
+			[UsedImplicitly]
+			public Lists Sealed { get; set; }
+		}
+
+		[UsedImplicitly]
+		class Concrete : OtherAbstractBase {}
+
+		class NonReferencingVariable
+		{
+			[UsedImplicitly]
+			public AbstractBase Abstract { get; set; }
+
+			[UsedImplicitly]
+			public OtherAbstractBase OtherAbstractBase { get; set; }
+
+			[UsedImplicitly]
+			public Identity Identity { get; set; }
+		}
+
+		
+		abstract class AbstractBase {}
+
+		abstract class OtherAbstractBase {}
+	}
+}

--- a/test/ExtendedXmlSerializerTest/ExtensionModel/OptimizedNamespaceExtensionTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtensionModel/OptimizedNamespaceExtensionTests.cs
@@ -24,6 +24,8 @@
 using System.Collections.Generic;
 using ExtendedXmlSerialization.Configuration;
 using ExtendedXmlSerialization.ExtensionModel;
+using LightInject;
+using Microsoft.DotNet.ProjectModel;
 using Xunit;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -56,6 +58,26 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 			var serializer = new ExtendedXmlConfiguration().Extend(OptimizedNamespaceExtension.Default).Create();
 			var data = serializer.Serialize(instance);
 			Assert.Equal(expected, data);
+		}
+
+		[Fact]
+		public void OptimizedDictionary()
+		{
+			const string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><OptimizedNamespaceExtensionTests-ClassWithDifferingPropertyType xmlns=""clr-namespace:ExtendedXmlSerialization.Test.ExtensionModel;assembly=ExtendedXmlSerializerTest"" xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" xmlns:sys=""https://github.com/wojtpl2/ExtendedXmlSerializer/system"" xmlns:ns1=""clr-namespace:LightInject;assembly=LightInject"" xmlns:ns2=""clr-namespace:Microsoft.DotNet.ProjectModel;assembly=Microsoft.DotNet.ProjectModel""><Interface exs:type=""OptimizedNamespaceExtensionTests-GeneralImplementation""><Instance exs:type=""sys:Dictionary[sys:Object,sys:Object]""><sys:Item><Key exs:type=""ns2:AnalyzerOptions"" /><Value exs:type=""ns1:DecoratorRegistration""><Index>0</Index></Value></sys:Item></Instance></Interface></OptimizedNamespaceExtensionTests-ClassWithDifferingPropertyType>";
+			var instance = new ClassWithDifferingPropertyType
+			               {
+				               Interface = new GeneralImplementation
+				                           {
+					                           Instance = new Dictionary<object, object>
+					                                      {
+						                                      {new AnalyzerOptions(), new DecoratorRegistration()}
+					                                      }
+				                           }
+			               };
+			var serializer = new ExtendedXmlConfiguration().Extend(OptimizedNamespaceExtension.Default).Create();
+			var data = serializer.Serialize(instance);
+			Assert.Equal(expected, data);
+			
 		}
 
 		class ClassWithDifferingPropertyType

--- a/test/ExtendedXmlSerializerTest/ExtensionModel/ReferencesExtensionTests.cs
+++ b/test/ExtendedXmlSerializerTest/ExtensionModel/ReferencesExtensionTests.cs
@@ -113,9 +113,9 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 			                                                    }));
 
 			var members = new MemberConfiguration(new Dictionary<MemberInfo, IConverter>
-			                                                  {
-				                                                  {descriptor.Metadata, IntegerConverter.Default}
-			                                                  });
+			                                      {
+				                                      {descriptor.Metadata, IntegerConverter.Default}
+			                                      });
 			var support = new SerializationSupport(new ExtendedXmlConfiguration(members).Extend(sut).Create());
 
 			var instance = new TestClassReference
@@ -131,7 +131,8 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 				                 new TestClassReference {Id = 4}
 			                 };
 
-			var actual = support.Assert(instance, @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassReference Id=""1"" xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><CyclicReference xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /><ObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""2"" /><ReferenceToObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""2"" /><Lists><Capacity>4</Capacity><TestClassReference Id=""3"" /><TestClassReference Id=""4"" /></Lists></TestClassReference>");
+			var actual = support.Assert(instance,
+			                            @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassReference Id=""1"" xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><CyclicReference xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /><ObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""2"" /><ReferenceToObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""2"" /><Lists><Capacity>4</Capacity><TestClassReference Id=""3"" /><TestClassReference Id=""4"" /></Lists></TestClassReference>");
 			Assert.NotNull(actual.ObjectA);
 			Assert.Same(instance, instance.CyclicReference);
 			Assert.Same(instance.ObjectA, instance.ReferenceToObjectA);
@@ -151,27 +152,29 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 			                                                    }));
 
 			var members = new MemberConfiguration(new Dictionary<MemberInfo, IConverter>
-			                                                  {
-				                                                  {descriptor.Metadata, IntegerConverter.Default}
-			                                                  });
+			                                      {
+				                                      {descriptor.Metadata, IntegerConverter.Default}
+			                                      });
 			var support = new SerializationSupport(new ExtendedXmlConfiguration(members).Extend(sut).Create());
 
 			var instance = new TestClassReferenceWithList {Parent = new TestClassReference {Id = 1}};
 			var other = new TestClassReference {Id = 2, ObjectA = instance.Parent, ReferenceToObjectA = instance.Parent};
 			instance.All = new List<IReference>
-			          {
-				          new TestClassReference {Id = 3, ObjectA = instance.Parent, ReferenceToObjectA = instance.Parent},
-				          new TestClassReference {Id = 4, ObjectA = other, ReferenceToObjectA = other},
-				          other,
-				          instance.Parent
-			          };
-			var actual = support.Assert(instance, @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassReferenceWithList xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Parent xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""1"" /><All><Capacity>4</Capacity><TestClassReference Id=""3""><ObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /></TestClassReference><TestClassReference Id=""4""><ObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""2""><ObjectA exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""1"" /></ObjectA><ReferenceToObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""2"" /></TestClassReference><TestClassReference xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:entity=""2"" /><TestClassReference xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:entity=""1"" /></All></TestClassReferenceWithList>");
+			               {
+				               new TestClassReference {Id = 3, ObjectA = instance.Parent, ReferenceToObjectA = instance.Parent},
+				               new TestClassReference {Id = 4, ObjectA = other, ReferenceToObjectA = other},
+				               other,
+				               instance.Parent
+			               };
+			var actual = support.Assert(instance,
+			                            @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassReferenceWithList xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Parent xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""1"" /><All><Capacity>4</Capacity><TestClassReference Id=""3""><ObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /></TestClassReference><TestClassReference Id=""4""><ObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""2""><ObjectA exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""1"" /></ObjectA><ReferenceToObjectA xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""2"" /></TestClassReference><TestClassReference xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:entity=""2"" /><TestClassReference xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:entity=""1"" /></All></TestClassReferenceWithList>");
 			Assert.NotNull(actual.Parent);
 			var list = actual.All.Cast<TestClassReference>().ToList();
 			Assert.Same(actual.Parent, list[0].ObjectA);
 			Assert.Same(actual.Parent, list[0].ReferenceToObjectA);
 			Assert.Same(list[1].ObjectA, list[1].ReferenceToObjectA);
-			Assert.Same(list[1].ObjectA.To<TestClassReference>().ObjectA, list[1].ObjectA.To<TestClassReference>().ReferenceToObjectA);
+			Assert.Same(list[1].ObjectA.To<TestClassReference>().ObjectA,
+			            list[1].ObjectA.To<TestClassReference>().ReferenceToObjectA);
 			Assert.Same(actual.Parent, list[1].ObjectA.To<TestClassReference>().ObjectA);
 			Assert.Same(list[2], list[1].ObjectA);
 			Assert.Same(actual.Parent, list[3]);
@@ -189,22 +192,23 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 			                                                    }));
 
 			var members = new MemberConfiguration(new Dictionary<MemberInfo, IConverter>
-			                                                  {
-				                                                  {descriptor.Metadata, IntegerConverter.Default}
-			                                                  });
+			                                      {
+				                                      {descriptor.Metadata, IntegerConverter.Default}
+			                                      });
 			var support = new SerializationSupport(new ExtendedXmlConfiguration(members).Extend(sut).Create());
 
 			var instance = new TestClassReferenceWithDictionary {Parent = new TestClassReference {Id = 1}};
 			var other = new TestClassReference {Id = 2, ObjectA = instance.Parent, ReferenceToObjectA = instance.Parent};
 
 			instance.All = new Dictionary<int, IReference>
-			          {
-				          {3, new TestClassReference {Id = 3, ObjectA = instance.Parent, ReferenceToObjectA = instance.Parent}},
-				          {4, new TestClassReference {Id = 4, ObjectA = other, ReferenceToObjectA = other}},
-				          {2, other},
-				          {1, instance.Parent}
-			          };
-			var actual = support.Assert(instance, @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassReferenceWithDictionary xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Parent xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""1"" /><All><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>3</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""3""><ObjectA exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""1"" /></Value></Item><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>4</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""4""><ObjectA exs:type=""TestClassReference"" Id=""2""><ObjectA exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""1"" /></ObjectA><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""2"" /></Value></Item><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>2</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""2"" /></Item><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>1</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /></Item></All></TestClassReferenceWithDictionary>");
+			               {
+				               {3, new TestClassReference {Id = 3, ObjectA = instance.Parent, ReferenceToObjectA = instance.Parent}},
+				               {4, new TestClassReference {Id = 4, ObjectA = other, ReferenceToObjectA = other}},
+				               {2, other},
+				               {1, instance.Parent}
+			               };
+			var actual = support.Assert(instance,
+			                            @"<?xml version=""1.0"" encoding=""utf-8""?><TestClassReferenceWithDictionary xmlns=""clr-namespace:ExtendedXmlSerialization.Test.TestObject;assembly=ExtendedXmlSerializerTest""><Parent xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""1"" /><All><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>3</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""3""><ObjectA exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""1"" /></Value></Item><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>4</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" Id=""4""><ObjectA exs:type=""TestClassReference"" Id=""2""><ObjectA exs:type=""TestClassReference"" exs:entity=""1"" /><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""1"" /></ObjectA><ReferenceToObjectA exs:type=""TestClassReference"" exs:entity=""2"" /></Value></Item><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>2</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""2"" /></Item><Item xmlns=""https://github.com/wojtpl2/ExtendedXmlSerializer/system""><Key>1</Key><Value xmlns:exs=""https://github.com/wojtpl2/ExtendedXmlSerializer/v2"" exs:type=""TestClassReference"" exs:entity=""1"" /></Item></All></TestClassReferenceWithDictionary>");
 			Assert.NotNull(actual.Parent);
 			var list = actual.All;
 			Assert.Same(actual.Parent, list[3].To<TestClassReference>().ObjectA);
@@ -227,9 +231,9 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 			                                                    }));
 
 			var members = new MemberConfiguration(new Dictionary<MemberInfo, IConverter>
-			                                                  {
-				                                                  {descriptor.Metadata, IntegerConverter.Default}
-			                                                  });
+			                                      {
+				                                      {descriptor.Metadata, IntegerConverter.Default}
+			                                      });
 			var support = new SerializationSupport(new ExtendedXmlConfiguration(members).Extend(sut).Create());
 
 			var parent = new TestClassReference {Id = 1};
@@ -249,6 +253,25 @@ namespace ExtendedXmlSerialization.Test.ExtensionModel
 			Assert.Same(actual[1].To<TestClassReference>().ObjectA, actual[1].To<TestClassReference>().ReferenceToObjectA);
 			Assert.Same(actual[2], actual[1].To<TestClassReference>().ObjectA);
 			Assert.Same(actual[3], actual[0].To<TestClassReference>().ObjectA);
+		}
+
+		[Fact]
+		public void VerifyThrow()
+		{
+			Assert.Throws<CircularReferencesDetectedException>(() =>
+			                                                   {
+				                                                   var support =
+					                                                   new SerializationSupport(new ExtendedXmlConfiguration().Create());
+				                                                   var instance = new Subject
+				                                                                  {
+					                                                                  Id =
+						                                                                  new Guid(
+							                                                                  "{0E2DECA4-CC38-46BA-9C47-94B8070D7353}"),
+					                                                                  PropertyName = "Hello World!"
+				                                                                  };
+				                                                   instance.Self = instance;
+				                                                   support.Serialize(instance);
+			                                                   });
 		}
 
 		class Subject

--- a/test/ExtendedXmlSerializerTest/Support/SerializationSupport.cs
+++ b/test/ExtendedXmlSerializerTest/Support/SerializationSupport.cs
@@ -1,4 +1,27 @@
-﻿using System.IO;
+﻿// MIT License
+// 
+// Copyright (c) 2016 Wojciech Nagórski
+//                    Michael DeMond
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.IO;
 using ExtendedXmlSerialization.Configuration;
 
 namespace ExtendedXmlSerialization.Test.Support

--- a/test/ExtendedXmlSerializerTest/Support/ServicesSupport.cs
+++ b/test/ExtendedXmlSerializerTest/Support/ServicesSupport.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using ExtendedXmlSerialization.Configuration;
+using ExtendedXmlSerialization.ContentModel;
+using ExtendedXmlSerialization.ContentModel.Converters;
+using ExtendedXmlSerialization.ContentModel.Xml;
+using ExtendedXmlSerialization.ExtensionModel;
+using LightInject;
+
+namespace ExtendedXmlSerialization.Test.Support
+{
+	class ServicesSupport : IServices
+	{
+		readonly static ISerializerExtension[] Empty = {};
+
+		readonly IServices _services;
+
+		public ServicesSupport() : this(Empty) {}
+
+		public ServicesSupport(params ISerializerExtension[] extensions) : this(extensions, new Instances(Activation.Default, new MemberConfiguration(),
+		                                                                                                  ContentSource.Default.Get(WellKnownConverters.Default),
+		                                                                                                  new XmlFactory(new XmlReaderSettings(), new XmlWriterSettings())).ToArray()) {}
+		public ServicesSupport(IEnumerable<ISerializerExtension> extensions, params object[] services) : this(new ConfiguredServices(services).Get(extensions)) {}
+
+		public ServicesSupport(IServices services)
+		{
+			_services = services;
+		}
+
+		public object GetService(Type serviceType) => _services.GetService(serviceType);
+
+		public void Dispose() => _services.Dispose();
+
+		public IEnumerable<ServiceRegistration> AvailableServices => _services.AvailableServices;
+
+		public IServices Register(Type serviceType, Type implementingType) => _services.Register(serviceType, implementingType);
+
+		public IServices Register(Type serviceType, Type implementingType, string serviceName) => _services.Register(serviceType, implementingType, serviceName);
+
+		public IServices Register<TService, TImplementation>() where TImplementation : TService => _services.Register<TService, TImplementation>();
+
+		public IServices Register<TService, TImplementation>(string serviceName) where TImplementation : TService => _services.Register<TService, TImplementation>(serviceName);
+
+		public IServices Register<TService>() => _services.Register<TService>();
+
+		public IServices RegisterInstance<TService>(TService instance) => _services.RegisterInstance(instance);
+
+		public IServices RegisterInstance<TService>(TService instance, string serviceName) => _services.RegisterInstance(instance, serviceName);
+
+		public IServices RegisterInstance(Type serviceType, object instance) => _services.RegisterInstance(serviceType, instance);
+
+		public IServices RegisterInstance(Type serviceType, object instance, string serviceName) => _services.RegisterInstance(serviceType, instance, serviceName);
+
+		public IServices Register(Type serviceType) => _services.Register(serviceType);
+
+		public IServices Register<TService>(Func<IServiceFactory, TService> factory) => _services.Register(factory);
+
+		public IServices Register<T, TService>(Func<IServiceFactory, T, TService> factory) => _services.Register(factory);
+
+		public IServices Register<T, TService>(Func<IServiceFactory, T, TService> factory, string serviceName) => _services.Register(factory, serviceName);
+
+		public IServices Register<T1, T2, TService>(Func<IServiceFactory, T1, T2, TService> factory) => _services.Register(factory);
+
+		public IServices Register<T1, T2, TService>(Func<IServiceFactory, T1, T2, TService> factory, string serviceName) => _services.Register(factory, serviceName);
+
+		public IServices Register<T1, T2, T3, TService>(Func<IServiceFactory, T1, T2, T3, TService> factory) => _services.Register(factory);
+
+		public IServices Register<T1, T2, T3, TService>(Func<IServiceFactory, T1, T2, T3, TService> factory, string serviceName) => _services.Register(factory, serviceName);
+
+		public IServices Register<T1, T2, T3, T4, TService>(Func<IServiceFactory, T1, T2, T3, T4, TService> factory) => _services.Register(factory);
+
+		public IServices Register<T1, T2, T3, T4, TService>(Func<IServiceFactory, T1, T2, T3, T4, TService> factory, string serviceName) => _services.Register(factory, serviceName);
+
+		public IServices Register<TService>(Func<IServiceFactory, TService> factory, string serviceName) => _services.Register(factory, serviceName);
+
+		public IServices RegisterFallback(Func<Type, bool> predicate, Func<Type, object> factory) => _services.RegisterFallback(predicate, factory);
+
+		public IServices RegisterConstructorDependency<TDependency>(Func<IServiceFactory, ParameterInfo, TDependency> factory) => _services.RegisterConstructorDependency(factory);
+
+		public IServices RegisterConstructorDependency<TDependency>(Func<IServiceFactory, ParameterInfo, object[], TDependency> factory) => _services.RegisterConstructorDependency(factory);
+
+		public IServices Decorate(Type serviceType, Type decoratorType) => _services.Decorate(serviceType, decoratorType);
+
+		public IServices Decorate<TService, TDecorator>() where TDecorator : TService => _services.Decorate<TService, TDecorator>();
+
+		public IServices Decorate<TService>(Func<IServiceFactory, TService, TService> factory) => _services.Decorate(factory);
+	}
+}


### PR DESCRIPTION
This PR introduces basic circular reference checking and throws if the `ReferencesExtension` is not applied to the configuration container.