### PR TITLE
Issue #141 tests: Null serialization creates <Null /> node ignoring property name instead of using xsi:nil="true"

### DIFF
--- a/test/ExtendedXmlSerializer.Tests/ReportedIssues/Issue141Tests.cs
+++ b/test/ExtendedXmlSerializer.Tests/ReportedIssues/Issue141Tests.cs
@@ -17,7 +17,7 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
         public void ShouldPreserveNullStringValueIfDefaultIsNotNull()
         {
             var config = new ConfigurationContainer();
-            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            config.Emit(EmitBehaviors.Assigned);
             var serializer = config.Create();
 
             string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
@@ -30,7 +30,7 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
         public void ShouldPreserveNullObjectValueIfDefaultIsNotNull()
         {
             var config = new ConfigurationContainer();
-            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            config.Emit(EmitBehaviors.Assigned);
             var serializer = config.Create();
 
             string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
@@ -43,11 +43,11 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
         public void ShouldPreserveNullAttributeValueIfDefaultIsNotNull()
         {
             var config = new ConfigurationContainer();
-            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            config.Emit(EmitBehaviors.Assigned);
             config.ConfigureType<ClassWithDefautString>().Member(x => x.Attribute).Attribute();
             var serializer = config.Create();
 
-            string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
+            string xml = serializer.Serialize(new ClassWithDefautString() { Attribute = null, SubNode = null });
             var deserialized = serializer.Deserialize<ClassWithDefautString>(xml);
 
             deserialized.Attribute.Should().BeNull();    //fail
@@ -57,7 +57,7 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
         public void ShouldPreserveNullObjectValueIfEmitWhenReturnsTrue()
         {
             var config = new ConfigurationContainer();
-            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            config.Emit(EmitBehaviors.Assigned);
             config.ConfigureType<ClassWithDefautString>().Member(x => x.SubNode).EmitWhen(x => true);
             var serializer = config.Create();
 

--- a/test/ExtendedXmlSerializer.Tests/ReportedIssues/Issue141Tests.cs
+++ b/test/ExtendedXmlSerializer.Tests/ReportedIssues/Issue141Tests.cs
@@ -1,0 +1,82 @@
+﻿using ExtendedXmlSerializer;
+using ExtendedXmlSerializer.Configuration;
+using ExtendedXmlSerializer.ExtensionModel;
+using ExtendedXmlSerializer.ExtensionModel.Content;
+using ExtendedXmlSerializer.ExtensionModel.Xml;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace ExtendedXmlSerializer.Tests.ReportedIssues
+{
+    public class Issue141Tests
+    {
+        [Fact]
+        public void ShouldPreserveNullStringValueIfDefaultIsNotNull()
+        {
+            var config = new ConfigurationContainer();
+            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            var serializer = config.Create();
+
+            string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
+            var deserialized = serializer.Deserialize<ClassWithDefautString>(xml);
+
+            deserialized.Name.Should().BeNull();    //fail
+        }
+
+        [Fact]
+        public void ShouldPreserveNullObjectValueIfDefaultIsNotNull()
+        {
+            var config = new ConfigurationContainer();
+            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            var serializer = config.Create();
+
+            string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
+            var deserialized = serializer.Deserialize<ClassWithDefautString>(xml);
+
+            deserialized.SubNode.Should().BeNull();    //fail
+        }
+
+        [Fact]
+        public void ShouldPreserveNullAttributeValueIfDefaultIsNotNull()
+        {
+            var config = new ConfigurationContainer();
+            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            config.ConfigureType<ClassWithDefautString>().Member(x => x.Attribute).Attribute();
+            var serializer = config.Create();
+
+            string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
+            var deserialized = serializer.Deserialize<ClassWithDefautString>(xml);
+
+            deserialized.Attribute.Should().BeNull();    //fail
+        }
+
+        [Fact]
+        public void ShouldPreserveNullObjectValueIfEmitWhenReturnsTrue()
+        {
+            var config = new ConfigurationContainer();
+            config.Emit(EmitBehaviors.Assigned); //no matter what we put here
+            config.ConfigureType<ClassWithDefautString>().Member(x => x.SubNode).EmitWhen(x => true);
+            var serializer = config.Create();
+
+            string xml = serializer.Serialize(new ClassWithDefautString() { Name = null, SubNode = null });
+            var deserialized = serializer.Deserialize<ClassWithDefautString>(xml);
+
+            deserialized.Attribute.Should().BeNull();    //fail
+        }
+
+        public class ClassWithDefautString
+        {
+            public string Name { get; set; } = "Unnamed";
+            public string Attribute { get; set; } = "Unset";
+            public SubClassWithDefautString SubNode { get; set; } = new SubClassWithDefautString();
+        }
+
+        public class SubClassWithDefautString
+        {
+            public string Name { get; set; } = "UnnamedSubclass";
+        }
+    }
+}


### PR DESCRIPTION
I`ve added tests for issue #141 as I think the correct behaviour should be