### PR TITLE
MemberInfo Configuration

### DIFF
--- a/src/ExtendedXmlSerializer/Configuration/Extensions.cs
+++ b/src/ExtendedXmlSerializer/Configuration/Extensions.cs
@@ -152,6 +152,12 @@ namespace ExtendedXmlSerializer.Configuration
 			return @this;
 		}
 
+		public static ITypeConfiguration<T> Member<T>(this ITypeConfiguration<T> @this, MemberInfo member, Action<IMemberConfiguration<T>> configure)
+		{
+				configure(((IInternalTypeConfiguration)@this).Member(member).AsValid<IMemberConfiguration<T>>());
+				return @this;
+		}
+
 		internal static IMemberConfiguration Member(this ITypeConfiguration @this, string member)
 		{
 			var metadata = @this.Get()

--- a/src/ExtendedXmlSerializer/Configuration/IMemberConfiguration.cs
+++ b/src/ExtendedXmlSerializer/Configuration/IMemberConfiguration.cs
@@ -28,7 +28,9 @@ using ExtendedXmlSerializer.Core.Sources;
 
 namespace ExtendedXmlSerializer.Configuration
 {
-	public interface IMemberConfiguration<T, TMember> : IMemberConfiguration, ITypeConfiguration<T> {}
+	public interface IMemberConfiguration<T, TMember> : IMemberConfiguration<T> {}
+
+	public interface IMemberConfiguration<T> : IMemberConfiguration, ITypeConfiguration<T> {}
 
 	// ReSharper disable once PossibleInterfaceMemberAmbiguity
 	public interface IMemberConfiguration : ITypeConfiguration, ISource<MemberInfo> {}

--- a/src/ExtendedXmlSerializer/ExtensionModel/Content/Extensions.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/Content/Extensions.cs
@@ -1,4 +1,4 @@
-﻿// MIT License
+// MIT License
 //
 // Copyright (c) 2016-2018 Wojciech Nagórski
 //                    Michael DeMond
@@ -75,6 +75,24 @@ namespace ExtendedXmlSerializer.ExtensionModel.Content
 		{
 			@this.Root.Find<AllowedMemberValuesExtension>()
 			     .Instances[@this.GetMember()] = new DelegatedSpecification<T>(specification).AdaptForNull();
+			return @this;
+		}
+
+		public static IMemberConfiguration<T> EmitWhen<T>(this IMemberConfiguration<T> @this,
+			Func<object, bool> specification)
+		{
+			@this.Root.Find<AllowedMemberValuesExtension>()
+					.Specifications[@this.GetMember()] =
+				new AllowedValueSpecification(new DelegatedSpecification<object>(specification).AdaptForNull());
+			return @this;
+		}
+
+		public static IMemberConfiguration<T> EmitWhenInstance<T>(
+			this IMemberConfiguration<T> @this,
+			Func<T, bool> specification)
+		{
+			@this.Root.Find<AllowedMemberValuesExtension>()
+				.Instances[@this.GetMember()] = new DelegatedSpecification<T>(specification).AdaptForNull();
 			return @this;
 		}
 

--- a/test/ExtendedXmlSerializer.Tests/ExtensionModel/Content/Members/AllowedMembersExtensionTests.cs
+++ b/test/ExtendedXmlSerializer.Tests/ExtensionModel/Content/Members/AllowedMembersExtensionTests.cs
@@ -1,4 +1,4 @@
-﻿// MIT License
+// MIT License
 //
 // Copyright (c) 2016-2018 Wojciech Nagórski
 //                    Michael DeMond
@@ -86,6 +86,23 @@ namespace ExtendedXmlSerializer.Tests.ExtensionModel.Content.Members
 			var actual = support.Cycle(instance);
 			Assert.NotEqual(instance.Property1, actual.Property1);
 			Assert.Equal(instance.Property2, actual.Property2);
+			Assert.Equal(instance.Property3, actual.Property3);
+		}
+
+		[Fact]
+		public void MemberInfoConfiguration()
+		{
+			var container = new ConfigurationContainer();
+			var type = container.Type<Subject>();
+			var memberInfo = typeof(Subject).GetProperty(nameof(Subject.Property1));
+			type.Member(memberInfo, c => c.EmitWhen(v => (string)v == "ABC"));
+			memberInfo = typeof(Subject).GetProperty(nameof(Subject.Property2));
+			type.Member(memberInfo, c => c.EmitWhenInstance(subject => subject.Property2 == 3));
+			var support = new SerializationSupport(container);
+			var instance = new Subject { Property1 = "AB", Property2 = 1000, Property3 = DateTime.Now };
+			var actual = support.Cycle(instance);
+			Assert.NotEqual(instance.Property1, actual.Property1);
+			Assert.NotEqual(instance.Property2, actual.Property2);
 			Assert.Equal(instance.Property3, actual.Property3);
 		}
 


### PR DESCRIPTION
Great job on the library!

This PR is for configuration of a member declared via the MemberInfo parameter extension method.

I was using the library to build a generic serializer and the changes I've made, in my case, are to manage this scenario:

```csharp
var extendedXmlSerializer = new ConfigurationContainer()
    .EnableImplicitTyping(typeof(T))
    .Type<T>(c =>
    {
        foreach (var propertyInfo in nullableProperties)
        {
            var memberConfiguration = c.Member(propertyInfo).Get(propertyInfo);
            memberConfiguration.Root.Find<AllowedMemberValuesExtension>().Instances[propertyInfo] = new DelegatedSpecification<object>(v => propertyInfo.GetValue(v) != null).AdaptForNull();
        }
    })
    .Create();
```

So instead of the code above, I can simply write:

```csharp
var extendedXmlSerializer = new ConfigurationContainer()
    .EnableImplicitTyping(typeof(T))
    .Type<T>(c =>
    {
        foreach (var propertyInfo in nullableProperties)
        {
            c.Member(propertyInfo, mc => mc.EmitWhen(v => v != null));
        }
    })
    .Create();
```

This change covers my serialization needs. A unit test was implemented to validate the three extension methods created.

Cheers